### PR TITLE
gi_core refactor

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,11 +18,11 @@ jobs:
     strategy:
       matrix:
         include:
-          - operating-system: windows-latest
-            vcpkgPackages: Qt5 gdcm boost
-            vcpkgTriplet: 'x64-windows'
-            useVcpkgToolchainFile: true
-            cmakeGenerator: 'VS16Win64'
+          #- operating-system: windows-latest
+          #  vcpkgPackages: Qt5 gdcm boost
+          #  vcpkgTriplet: 'x64-windows'
+          #  useVcpkgToolchainFile: true
+          #  cmakeGenerator: 'VS16Win64'
           - operating-system: ubuntu-latest            
             cmakeGenerator: 'Ninja'
             useVcpkgToolchainFile: false
@@ -46,14 +46,14 @@ jobs:
 # Step below not only installs and does VCPKG setup but also installs dependency packages and store them in cache
 # cache is crucial, as installation (compilation from sources) of many dependencies is time consuming
 # i.e. wxwidgets needs >10min for installation and <1min for retrieval from cache
-    - name: Install Windows requirements
-      if: ${{ runner.os == 'Windows' }}
-      uses: lukka/run-vcpkg@v7.3
-      with:
-        vcpkgArguments: '${{ matrix.vcpkgPackages }}'
-        vcpkgTriplet: 'x64-windows'
-        vcpkgDirectory: '${{ runner.workspace }}/b/vcpkg'
-        vcpkgGitCommitId: '5568f110b509a9fd90711978a7cb76bae75bb092'
+    #- name: Install Windows requirements
+    #  if: ${{ runner.os == 'Windows' }}
+    #  uses: lukka/run-vcpkg@v7.3
+    #  with:
+    #    vcpkgArguments: '${{ matrix.vcpkgPackages }}'
+    #    vcpkgTriplet: 'x64-windows'
+    #    vcpkgDirectory: '${{ runner.workspace }}/b/vcpkg'
+    #    vcpkgGitCommitId: '5568f110b509a9fd90711978a7cb76bae75bb092'
 
     - name: Configure and build with CMake
       uses: lukka/run-cmake@v3.4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         include:
           - operating-system: windows-latest
-            vcpkgPackages: Qt5 gdcm
+            vcpkgPackages: Qt5 gdcm boost
             vcpkgTriplet: 'x64-windows'
             useVcpkgToolchainFile: true
             cmakeGenerator: 'VS16Win64'
@@ -30,11 +30,18 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Install GCC 10 Linux
+      if: ${{ runner.os == 'Linux' }}
+      uses: egor-tensin/setup-gcc@v1
+      with:
+          version: 10
+          platform: x64
+
     - name: Install Linux requirements
       if: ${{ runner.os == 'Linux' }}
       run: |
            sudo apt update
-           sudo apt install qt5-default libgdcm3.0 libgdcm-dev
+           sudo apt install qt5-default libgdcm3.0 libgdcm-dev libboost-all-dev
 
 # Step below not only installs and does VCPKG setup but also installs dependency packages and store them in cache
 # cache is crucial, as installation (compilation from sources) of many dependencies is time consuming
@@ -54,10 +61,14 @@ jobs:
           vcpkgTriplet: '${{ matrix.vcpkgTriplet }}'  # VCPKG target specification (so called "triplet"), here used only on Windows
           cmakeBuildType: ${{env.BUILD_TYPE}}  # Release or Debug
           cmakeGenerator: '${{ matrix.cmakeGenerator }}'  # specify generator (i.e. Ninja or Visual Studio)
-          buildDirectory: '_build'  # subdirectory to store make build and store results
+          buildDirectory: 'build'  # subdirectory to store make build and store results
           buildWithCMake: true  # use CMake to trigger build process
           useVcpkgToolchainFile: '${{ matrix.useVcpkgToolchainFile }}'  # use vcpkg to install dependencies (i.e. wxwidgets) on Windows
 
+    - name: Run unit tests
+      run: |
+           build/bin/release/gi_core_tests --log_level=message
+#           build/bin/release/gi_gdcm_wrapper_tests --log_level=message
 #     Uncomment section below to enable tests
 #     - name: Test
 #       working-directory: ${{github.workspace}}/gi_core/build

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+# CMake build output directory #
+[Bb]uild
+
+# CMake target output directory #
+[Bb]in
+
+### CLion ###
+.idea
+cmake-*
+
+### VisualStudio ###
+.vs

--- a/README.md
+++ b/README.md
@@ -2,4 +2,15 @@
 
 Application and library for performing efficient comparisons of 2D, 3D DICOM images using gamma index concept.
 
-For all the details concerning the yAGIT project please see the [documentation](http://gi-yagit.readthedocs.io/en/latest/).
+## Used libraries
+* [simdpp](https://github.com/p12tic/libsimdpp) - code vectorization
+* [VexCL](https://github.com/ddemidov/vexcl) - OpenCL/CUDA GPU offloading
+* [GDCM](http://gdcm.sourceforge.net/) - interacting with DICOM files
+* [boost](https://www.boost.org/) - unit testing
+* [Qt5](https://www.qt.io/) - GUI
+
+## C++ standard
+Project is written under C++20
+
+## Documentation
+[Documentation](http://gi-yagit.readthedocs.io/en/latest/)

--- a/README.md
+++ b/README.md
@@ -9,6 +9,13 @@ Application and library for performing efficient comparisons of 2D, 3D DICOM ima
 * [boost](https://www.boost.org/) - unit testing
 * [Qt5](https://www.qt.io/) - GUI
 
+## Building
+
+Building project requires CMake.
+To generate project compiler with C++20 support is required.
+CMake environment requires Qt5, boost and GDCM libraries to be installed
+the project does not pull them automatically.
+
 ## C++ standard
 Project is written under C++20
 

--- a/gi_core/CMakeLists.txt
+++ b/gi_core/CMakeLists.txt
@@ -19,22 +19,69 @@ project(gi_core)
 
 set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH};${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 include(common)
+include(CPM)
 
-find_c_and_cpp_files("${CMAKE_CURRENT_SOURCE_DIR}/include" gi_core_includes)
+# GI_CORE
+
+find_package(Boost COMPONENTS system filesystem unit_test_framework REQUIRED)
+find_package(OpenMP)
+
+CPMFindPackage(
+  NAME libsimdpp
+  GITHUB_REPOSITORY TheTryton/libsimdpp
+  VERSION 2.1.1
+)
+
+CPMFindPackage(
+  NAME vexcl
+  GITHUB_REPOSITORY ddemidov/vexcl
+  GIT_TAG 1.4.2
+)
+
+find_c_and_cpp_files("${CMAKE_CURRENT_SOURCE_DIR}/include" gi_core_headers)
 find_c_and_cpp_files("${CMAKE_CURRENT_SOURCE_DIR}/src" gi_core_sources)
 find_c_and_cpp_files("${CMAKE_CURRENT_SOURCE_DIR}/compat" gi_core_compatibility_sources)
 
-source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${gi_core_includes} ${gi_core_sources} ${gi_core_compatibility_sources})
+set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH};${libsimdpp_SOURCE_DIR}/cmake")
+include(SimdppMultiarch)
+simdpp_get_compilable_archs(compilable_archs)
+simdpp_multiarch(generated_arch_files_d_ffaa "dispatch/data/allocation/fast_float_aligned_allocator_impl.cpp" ${compilable_archs})
+simdpp_multiarch(generated_arch_files_v "dispatch/math/vectorized/gamma_index_range_impl.cpp" ${compilable_archs})
+simdpp_multiarch(generated_arch_files_v_omp "dispatch/math/vectorized/openmp/gamma_index_range_impl.cpp" ${compilable_archs})
 
-add_library(gi_core STATIC ${gi_core_includes} ${gi_core_sources} ${gi_core_compatibility_sources})
-target_include_directories(gi_core PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/compat)
-target_include_directories(gi_core PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
+source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${gi_core_headers} ${gi_core_sources} ${gi_core_compatibility_sources})
+
+add_library(gi_core STATIC
+        ${gi_core_headers}
+        ${gi_core_sources}
+        ${generated_arch_files_d_ffaa}
+        ${generated_arch_files_v}
+        ${generated_arch_files_v_omp}
+        ${gi_core_compatibility_sources})
+#target_link_libraries(gi_core PUBLIC VexCL::OpenCL) not linking as for the moment GPU support is not developed
+target_include_directories(gi_core PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include ${CMAKE_CURRENT_SOURCE_DIR}/compat ${libsimdpp_SOURCE_DIR})
+target_include_directories(gi_core PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
+if (OPENMP_FOUND)
+    set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
+    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+    set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}")
+    target_compile_definitions(gi_core PUBLIC -DYAGIT_OPENMP)
+else()
+	message(WARNING "Selected compiler doesn't support OPENMP!")
+endif()
+
+target_compile_definitions(gi_core PUBLIC -DVEXCL_SHOW_KERNELS)
 
 set_target_properties(gi_core
     PROPERTIES
-    CXX_STANDARD 17
+    CXX_STANDARD 20
     CXX_STANDARD_REQUIRED YES
     CXX_EXTENSIONS NO
 )
 
 set_default_output_directories(gi_core)
+
+# GI_CORE_TESTS
+add_subdirectory(tests)
+# GI_PERFORMANCE_ANALYSIS
+add_subdirectory(performance_analysis)

--- a/gi_core/cmake/CPM.cmake
+++ b/gi_core/cmake/CPM.cmake
@@ -1,0 +1,994 @@
+# CPM.cmake - CMake's missing package manager
+# ===========================================
+# See https://github.com/cpm-cmake/CPM.cmake for usage and update instructions.
+#
+# MIT License
+# -----------
+#[[
+  Copyright (c) 2021 Lars Melchior and additional contributors
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+]]
+
+cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
+
+set(CURRENT_CPM_VERSION 1.0.0-development-version)
+
+if(CPM_DIRECTORY)
+  if(NOT CPM_DIRECTORY STREQUAL CMAKE_CURRENT_LIST_DIR)
+    if(CPM_VERSION VERSION_LESS CURRENT_CPM_VERSION)
+      message(
+        AUTHOR_WARNING
+          "${CPM_INDENT} \
+A dependency is using a more recent CPM version (${CURRENT_CPM_VERSION}) than the current project (${CPM_VERSION}). \
+It is recommended to upgrade CPM to the most recent version. \
+See https://github.com/cpm-cmake/CPM.cmake for more information."
+      )
+    endif()
+    if(${CMAKE_VERSION} VERSION_LESS "3.17.0")
+      include(FetchContent)
+    endif()
+    return()
+  endif()
+
+  get_property(
+    CPM_INITIALIZED GLOBAL ""
+    PROPERTY CPM_INITIALIZED
+    SET
+  )
+  if(CPM_INITIALIZED)
+    return()
+  endif()
+endif()
+
+set_property(GLOBAL PROPERTY CPM_INITIALIZED true)
+
+option(CPM_USE_LOCAL_PACKAGES "Always try to use `find_package` to get dependencies"
+       $ENV{CPM_USE_LOCAL_PACKAGES}
+)
+option(CPM_LOCAL_PACKAGES_ONLY "Only use `find_package` to get dependencies"
+       $ENV{CPM_LOCAL_PACKAGES_ONLY}
+)
+option(CPM_DOWNLOAD_ALL "Always download dependencies from source" $ENV{CPM_DOWNLOAD_ALL})
+option(CPM_DONT_UPDATE_MODULE_PATH "Don't update the module path to allow using find_package"
+       $ENV{CPM_DONT_UPDATE_MODULE_PATH}
+)
+option(CPM_DONT_CREATE_PACKAGE_LOCK "Don't create a package lock file in the binary path"
+       $ENV{CPM_DONT_CREATE_PACKAGE_LOCK}
+)
+option(CPM_INCLUDE_ALL_IN_PACKAGE_LOCK
+       "Add all packages added through CPM.cmake to the package lock"
+       $ENV{CPM_INCLUDE_ALL_IN_PACKAGE_LOCK}
+)
+option(CPM_USE_NAMED_CACHE_DIRECTORIES
+       "Use additional directory of package name in cache on the most nested level."
+       $ENV{CPM_USE_NAMED_CACHE_DIRECTORIES}
+)
+
+set(CPM_VERSION
+    ${CURRENT_CPM_VERSION}
+    CACHE INTERNAL ""
+)
+set(CPM_DIRECTORY
+    ${CMAKE_CURRENT_LIST_DIR}
+    CACHE INTERNAL ""
+)
+set(CPM_FILE
+    ${CMAKE_CURRENT_LIST_FILE}
+    CACHE INTERNAL ""
+)
+set(CPM_PACKAGES
+    ""
+    CACHE INTERNAL ""
+)
+set(CPM_DRY_RUN
+    OFF
+    CACHE INTERNAL "Don't download or configure dependencies (for testing)"
+)
+
+if(DEFINED ENV{CPM_SOURCE_CACHE})
+  set(CPM_SOURCE_CACHE_DEFAULT $ENV{CPM_SOURCE_CACHE})
+else()
+  set(CPM_SOURCE_CACHE_DEFAULT OFF)
+endif()
+
+set(CPM_SOURCE_CACHE
+    ${CPM_SOURCE_CACHE_DEFAULT}
+    CACHE PATH "Directory to download CPM dependencies"
+)
+
+if(NOT CPM_DONT_UPDATE_MODULE_PATH)
+  set(CPM_MODULE_PATH
+      "${CMAKE_BINARY_DIR}/CPM_modules"
+      CACHE INTERNAL ""
+  )
+  # remove old modules
+  file(REMOVE_RECURSE ${CPM_MODULE_PATH})
+  file(MAKE_DIRECTORY ${CPM_MODULE_PATH})
+  # locally added CPM modules should override global packages
+  set(CMAKE_MODULE_PATH "${CPM_MODULE_PATH};${CMAKE_MODULE_PATH}")
+endif()
+
+if(NOT CPM_DONT_CREATE_PACKAGE_LOCK)
+  set(CPM_PACKAGE_LOCK_FILE
+      "${CMAKE_BINARY_DIR}/cpm-package-lock.cmake"
+      CACHE INTERNAL ""
+  )
+  file(WRITE ${CPM_PACKAGE_LOCK_FILE}
+       "# CPM Package Lock\n# This file should be committed to version control\n\n"
+  )
+endif()
+
+include(FetchContent)
+
+# Try to infer package name from git repository uri (path or url)
+function(cpm_package_name_from_git_uri URI RESULT)
+  if("${URI}" MATCHES "([^/:]+)/?.git/?$")
+    set(${RESULT}
+        ${CMAKE_MATCH_1}
+        PARENT_SCOPE
+    )
+  else()
+    unset(${RESULT} PARENT_SCOPE)
+  endif()
+endfunction()
+
+# Try to infer package name and version from a url
+function(cpm_package_name_and_ver_from_url url outName outVer)
+  if(url MATCHES "[/\\?]([a-zA-Z0-9_\\.-]+)\\.(tar|tar\\.gz|tar\\.bz2|zip|ZIP)(\\?|/|$)")
+    # We matched an archive
+    set(filename "${CMAKE_MATCH_1}")
+
+    if(filename MATCHES "([a-zA-Z0-9_\\.-]+)[_-]v?(([0-9]+\\.)*[0-9]+[a-zA-Z0-9]*)")
+      # We matched <name>-<version> (ie foo-1.2.3)
+      set(${outName}
+          "${CMAKE_MATCH_1}"
+          PARENT_SCOPE
+      )
+      set(${outVer}
+          "${CMAKE_MATCH_2}"
+          PARENT_SCOPE
+      )
+    elseif(filename MATCHES "(([0-9]+\\.)+[0-9]+[a-zA-Z0-9]*)")
+      # We couldn't find a name, but we found a version
+      #
+      # In many cases (which we don't handle here) the url would look something like
+      # `irrelevant/ACTUAL_PACKAGE_NAME/irrelevant/1.2.3.zip`. In such a case we can't possibly
+      # distinguish the package name from the irrelevant bits. Moreover if we try to match the
+      # package name from the filename, we'd get bogus at best.
+      unset(${outName} PARENT_SCOPE)
+      set(${outVer}
+          "${CMAKE_MATCH_1}"
+          PARENT_SCOPE
+      )
+    else()
+      # Boldly assume that the file name is the package name.
+      #
+      # Yes, something like `irrelevant/ACTUAL_NAME/irrelevant/download.zip` will ruin our day, but
+      # such cases should be quite rare. No popular service does this... we think.
+      set(${outName}
+          "${filename}"
+          PARENT_SCOPE
+      )
+      unset(${outVer} PARENT_SCOPE)
+    endif()
+  else()
+    # No ideas yet what to do with non-archives
+    unset(${outName} PARENT_SCOPE)
+    unset(${outVer} PARENT_SCOPE)
+  endif()
+endfunction()
+
+# Initialize logging prefix
+if(NOT CPM_INDENT)
+  set(CPM_INDENT
+      "CPM:"
+      CACHE INTERNAL ""
+  )
+endif()
+
+function(cpm_find_package NAME VERSION)
+  string(REPLACE " " ";" EXTRA_ARGS "${ARGN}")
+  find_package(${NAME} ${VERSION} ${EXTRA_ARGS} QUIET)
+  if(${CPM_ARGS_NAME}_FOUND)
+    message(STATUS "${CPM_INDENT} using local package ${CPM_ARGS_NAME}@${VERSION}")
+    CPMRegisterPackage(${CPM_ARGS_NAME} "${VERSION}")
+    set(CPM_PACKAGE_FOUND
+        YES
+        PARENT_SCOPE
+    )
+  else()
+    set(CPM_PACKAGE_FOUND
+        NO
+        PARENT_SCOPE
+    )
+  endif()
+endfunction()
+
+# Create a custom FindXXX.cmake module for a CPM package This prevents `find_package(NAME)` from
+# finding the system library
+function(cpm_create_module_file Name)
+  if(NOT CPM_DONT_UPDATE_MODULE_PATH)
+    # erase any previous modules
+    file(WRITE ${CPM_MODULE_PATH}/Find${Name}.cmake
+         "include(\"${CPM_FILE}\")\n${ARGN}\nset(${Name}_FOUND TRUE)"
+    )
+  endif()
+endfunction()
+
+# Find a package locally or fallback to CPMAddPackage
+function(CPMFindPackage)
+  set(oneValueArgs NAME VERSION GIT_TAG FIND_PACKAGE_ARGUMENTS)
+
+  cmake_parse_arguments(CPM_ARGS "" "${oneValueArgs}" "" ${ARGN})
+
+  if(NOT DEFINED CPM_ARGS_VERSION)
+    if(DEFINED CPM_ARGS_GIT_TAG)
+      cpm_get_version_from_git_tag("${CPM_ARGS_GIT_TAG}" CPM_ARGS_VERSION)
+    endif()
+  endif()
+
+  if(CPM_DOWNLOAD_ALL)
+    CPMAddPackage(${ARGN})
+    cpm_export_variables(${CPM_ARGS_NAME})
+    return()
+  endif()
+
+  cpm_check_if_package_already_added(${CPM_ARGS_NAME} "${CPM_ARGS_VERSION}")
+  if(CPM_PACKAGE_ALREADY_ADDED)
+    cpm_export_variables(${CPM_ARGS_NAME})
+    return()
+  endif()
+
+  cpm_find_package(${CPM_ARGS_NAME} "${CPM_ARGS_VERSION}" ${CPM_ARGS_FIND_PACKAGE_ARGUMENTS})
+
+  if(NOT CPM_PACKAGE_FOUND)
+    CPMAddPackage(${ARGN})
+    cpm_export_variables(${CPM_ARGS_NAME})
+  endif()
+
+endfunction()
+
+# checks if a package has been added before
+function(cpm_check_if_package_already_added CPM_ARGS_NAME CPM_ARGS_VERSION)
+  if("${CPM_ARGS_NAME}" IN_LIST CPM_PACKAGES)
+    CPMGetPackageVersion(${CPM_ARGS_NAME} CPM_PACKAGE_VERSION)
+    if("${CPM_PACKAGE_VERSION}" VERSION_LESS "${CPM_ARGS_VERSION}")
+      message(
+        WARNING
+          "${CPM_INDENT} requires a newer version of ${CPM_ARGS_NAME} (${CPM_ARGS_VERSION}) than currently included (${CPM_PACKAGE_VERSION})."
+      )
+    endif()
+    cpm_get_fetch_properties(${CPM_ARGS_NAME})
+    set(${CPM_ARGS_NAME}_ADDED NO)
+    set(CPM_PACKAGE_ALREADY_ADDED
+        YES
+        PARENT_SCOPE
+    )
+    cpm_export_variables(${CPM_ARGS_NAME})
+  else()
+    set(CPM_PACKAGE_ALREADY_ADDED
+        NO
+        PARENT_SCOPE
+    )
+  endif()
+endfunction()
+
+# Parse the argument of CPMAddPackage in case a single one was provided and convert it to a list of
+# arguments which can then be parsed idiomatically. For example gh:foo/bar@1.2.3 will be converted
+# to: GITHUB_REPOSITORY;foo/bar;VERSION;1.2.3
+function(cpm_parse_add_package_single_arg arg outArgs)
+  # Look for a scheme
+  if("${arg}" MATCHES "^([a-zA-Z]+):(.+)$")
+    string(TOLOWER "${CMAKE_MATCH_1}" scheme)
+    set(uri "${CMAKE_MATCH_2}")
+
+    # Check for CPM-specific schemes
+    if(scheme STREQUAL "gh")
+      set(out "GITHUB_REPOSITORY;${uri}")
+      set(packageType "git")
+    elseif(scheme STREQUAL "gl")
+      set(out "GITLAB_REPOSITORY;${uri}")
+      set(packageType "git")
+    elseif(scheme STREQUAL "bb")
+      set(out "BITBUCKET_REPOSITORY;${uri}")
+      set(packageType "git")
+      # A CPM-specific scheme was not found. Looks like this is a generic URL so try to determine
+      # type
+    elseif(arg MATCHES ".git/?(@|#|$)")
+      set(out "GIT_REPOSITORY;${arg}")
+      set(packageType "git")
+    else()
+      # Fall back to a URL
+      set(out "URL;${arg}")
+      set(packageType "archive")
+
+      # We could also check for SVN since FetchContent supports it, but SVN is so rare these days.
+      # We just won't bother with the additional complexity it will induce in this function. SVN is
+      # done by multi-arg
+    endif()
+  else()
+    if(arg MATCHES ".git/?(@|#|$)")
+      set(out "GIT_REPOSITORY;${arg}")
+      set(packageType "git")
+    else()
+      # Give up
+      message(FATAL_ERROR "CPM: Can't determine package type of '${arg}'")
+    endif()
+  endif()
+
+  # For all packages we interpret @... as version. Only replace the last occurence. Thus URIs
+  # containing '@' can be used
+  string(REGEX REPLACE "@([^@]+)$" ";VERSION;\\1" out "${out}")
+
+  # Parse the rest according to package type
+  if(packageType STREQUAL "git")
+    # For git repos we interpret #... as a tag or branch or commit hash
+    string(REGEX REPLACE "#([^#]+)$" ";GIT_TAG;\\1" out "${out}")
+  elseif(packageType STREQUAL "archive")
+    # For archives we interpret #... as a URL hash.
+    string(REGEX REPLACE "#([^#]+)$" ";URL_HASH;\\1" out "${out}")
+    # We don't try to parse the version if it's not provided explicitly. cpm_get_version_from_url
+    # should do this at a later point
+  else()
+    # We should never get here. This is an assertion and hitting it means there's a bug in the code
+    # above. A packageType was set, but not handled by this if-else.
+    message(FATAL_ERROR "CPM: Unsupported package type '${packageType}' of '${arg}'")
+  endif()
+
+  set(${outArgs}
+      ${out}
+      PARENT_SCOPE
+  )
+endfunction()
+
+# Check that the working directory for a git repo is clean
+function(cpm_check_git_working_dir_is_clean repoPath gitTag isClean)
+
+  find_package(Git REQUIRED)
+
+  if(NOT GIT_EXECUTABLE)
+    # No git executable, assume directory is clean
+    set(${isClean}
+        TRUE
+        PARENT_SCOPE
+    )
+    return()
+  endif()
+
+  # check for uncommited changes
+  execute_process(
+    COMMAND ${GIT_EXECUTABLE} status --porcelain
+    RESULT_VARIABLE resultGitStatus
+    OUTPUT_VARIABLE repoStatus
+    OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_QUIET
+    WORKING_DIRECTORY ${repoPath}
+  )
+  if(resultGitStatus)
+    # not supposed to happen, assume clean anyway
+    message(WARNING "Calling git status on folder ${repoPath} failed")
+    set(${isClean}
+        TRUE
+        PARENT_SCOPE
+    )
+    return()
+  endif()
+
+  if(NOT "${repoStatus}" STREQUAL "")
+    set(${isClean}
+        FALSE
+        PARENT_SCOPE
+    )
+    return()
+  endif()
+
+  # check for commited changes
+  execute_process(
+    COMMAND ${GIT_EXECUTABLE} diff -s --exit-code ${gitTag}
+    RESULT_VARIABLE resultGitDiff
+    OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_QUIET
+    WORKING_DIRECTORY ${repoPath}
+  )
+
+  if(${resultGitDiff} EQUAL 0)
+    set(${isClean}
+        TRUE
+        PARENT_SCOPE
+    )
+  else()
+    set(${isClean}
+        FALSE
+        PARENT_SCOPE
+    )
+  endif()
+
+endfunction()
+
+# Download and add a package from source
+function(CPMAddPackage)
+  list(LENGTH ARGN argnLength)
+  if(argnLength EQUAL 1)
+    cpm_parse_add_package_single_arg("${ARGN}" ARGN)
+
+    # The shorthand syntax implies EXCLUDE_FROM_ALL
+    set(ARGN "${ARGN};EXCLUDE_FROM_ALL;YES")
+  endif()
+
+  set(oneValueArgs
+      NAME
+      FORCE
+      VERSION
+      GIT_TAG
+      DOWNLOAD_ONLY
+      GITHUB_REPOSITORY
+      GITLAB_REPOSITORY
+      BITBUCKET_REPOSITORY
+      GIT_REPOSITORY
+      SOURCE_DIR
+      DOWNLOAD_COMMAND
+      FIND_PACKAGE_ARGUMENTS
+      NO_CACHE
+      GIT_SHALLOW
+      EXCLUDE_FROM_ALL
+      SOURCE_SUBDIR
+  )
+
+  set(multiValueArgs URL OPTIONS)
+
+  cmake_parse_arguments(CPM_ARGS "" "${oneValueArgs}" "${multiValueArgs}" "${ARGN}")
+
+  # Set default values for arguments
+
+  if(NOT DEFINED CPM_ARGS_VERSION)
+    if(DEFINED CPM_ARGS_GIT_TAG)
+      cpm_get_version_from_git_tag("${CPM_ARGS_GIT_TAG}" CPM_ARGS_VERSION)
+    endif()
+  endif()
+
+  if(CPM_ARGS_DOWNLOAD_ONLY)
+    set(DOWNLOAD_ONLY ${CPM_ARGS_DOWNLOAD_ONLY})
+  else()
+    set(DOWNLOAD_ONLY NO)
+  endif()
+
+  if(DEFINED CPM_ARGS_GITHUB_REPOSITORY)
+    set(CPM_ARGS_GIT_REPOSITORY "https://github.com/${CPM_ARGS_GITHUB_REPOSITORY}.git")
+  elseif(DEFINED CPM_ARGS_GITLAB_REPOSITORY)
+    set(CPM_ARGS_GIT_REPOSITORY "https://gitlab.com/${CPM_ARGS_GITLAB_REPOSITORY}.git")
+  elseif(DEFINED CPM_ARGS_BITBUCKET_REPOSITORY)
+    set(CPM_ARGS_GIT_REPOSITORY "https://bitbucket.org/${CPM_ARGS_BITBUCKET_REPOSITORY}.git")
+  endif()
+
+  if(DEFINED CPM_ARGS_GIT_REPOSITORY)
+    list(APPEND CPM_ARGS_UNPARSED_ARGUMENTS GIT_REPOSITORY ${CPM_ARGS_GIT_REPOSITORY})
+    if(NOT DEFINED CPM_ARGS_GIT_TAG)
+      set(CPM_ARGS_GIT_TAG v${CPM_ARGS_VERSION})
+    endif()
+
+    # If a name wasn't provided, try to infer it from the git repo
+    if(NOT DEFINED CPM_ARGS_NAME)
+      cpm_package_name_from_git_uri(${CPM_ARGS_GIT_REPOSITORY} CPM_ARGS_NAME)
+    endif()
+  endif()
+
+  set(CPM_SKIP_FETCH FALSE)
+
+  if(DEFINED CPM_ARGS_GIT_TAG)
+    list(APPEND CPM_ARGS_UNPARSED_ARGUMENTS GIT_TAG ${CPM_ARGS_GIT_TAG})
+    # If GIT_SHALLOW is explicitly specified, honor the value.
+    if(DEFINED CPM_ARGS_GIT_SHALLOW)
+      list(APPEND CPM_ARGS_UNPARSED_ARGUMENTS GIT_SHALLOW ${CPM_ARGS_GIT_SHALLOW})
+    endif()
+  endif()
+
+  if(DEFINED CPM_ARGS_URL)
+    # If a name or version aren't provided, try to infer them from the URL
+    list(GET CPM_ARGS_URL 0 firstUrl)
+    cpm_package_name_and_ver_from_url(${firstUrl} nameFromUrl verFromUrl)
+    # If we fail to obtain name and version from the first URL, we could try other URLs if any.
+    # However multiple URLs are expected to be quite rare, so for now we won't bother.
+
+    # If the caller provided their own name and version, they trump the inferred ones.
+    if(NOT DEFINED CPM_ARGS_NAME)
+      set(CPM_ARGS_NAME ${nameFromUrl})
+    endif()
+    if(NOT DEFINED CPM_ARGS_VERSION)
+      set(CPM_ARGS_VERSION ${verFromUrl})
+    endif()
+
+    list(APPEND CPM_ARGS_UNPARSED_ARGUMENTS URL "${CPM_ARGS_URL}")
+  endif()
+
+  # Check for required arguments
+
+  if(NOT DEFINED CPM_ARGS_NAME)
+    message(
+      FATAL_ERROR
+        "CPM: 'NAME' was not provided and couldn't be automatically inferred for package added with arguments: '${ARGN}'"
+    )
+  endif()
+
+  # Check if package has been added before
+  cpm_check_if_package_already_added(${CPM_ARGS_NAME} "${CPM_ARGS_VERSION}")
+  if(CPM_PACKAGE_ALREADY_ADDED)
+    cpm_export_variables(${CPM_ARGS_NAME})
+    return()
+  endif()
+
+  # Check for manual overrides
+  if(NOT CPM_ARGS_FORCE AND NOT "${CPM_${CPM_ARGS_NAME}_SOURCE}" STREQUAL "")
+    set(PACKAGE_SOURCE ${CPM_${CPM_ARGS_NAME}_SOURCE})
+    set(CPM_${CPM_ARGS_NAME}_SOURCE "")
+    CPMAddPackage(
+      NAME "${CPM_ARGS_NAME}"
+      SOURCE_DIR "${PACKAGE_SOURCE}"
+      EXCLUDE_FROM_ALL "${CPM_ARGS_EXCLUDE_FROM_ALL}"
+      OPTIONS "${CPM_ARGS_OPTIONS}"
+      SOURCE_SUBDIR "${CPM_ARGS_SOURCE_SUBDIR}"
+      FORCE True
+    )
+    cpm_export_variables(${CPM_ARGS_NAME})
+    return()
+  endif()
+
+  # Check for available declaration
+  if(NOT CPM_ARGS_FORCE AND NOT "${CPM_DECLARATION_${CPM_ARGS_NAME}}" STREQUAL "")
+    set(declaration ${CPM_DECLARATION_${CPM_ARGS_NAME}})
+    set(CPM_DECLARATION_${CPM_ARGS_NAME} "")
+    CPMAddPackage(${declaration})
+    cpm_export_variables(${CPM_ARGS_NAME})
+    # checking again to ensure version and option compatibility
+    cpm_check_if_package_already_added(${CPM_ARGS_NAME} "${CPM_ARGS_VERSION}")
+    return()
+  endif()
+
+  if(CPM_USE_LOCAL_PACKAGES OR CPM_LOCAL_PACKAGES_ONLY)
+    cpm_find_package(${CPM_ARGS_NAME} "${CPM_ARGS_VERSION}" ${CPM_ARGS_FIND_PACKAGE_ARGUMENTS})
+
+    if(CPM_PACKAGE_FOUND)
+      cpm_export_variables(${CPM_ARGS_NAME})
+      return()
+    endif()
+
+    if(CPM_LOCAL_PACKAGES_ONLY)
+      message(
+        SEND_ERROR
+          "CPM: ${CPM_ARGS_NAME} not found via find_package(${CPM_ARGS_NAME} ${CPM_ARGS_VERSION})"
+      )
+    endif()
+  endif()
+
+  CPMRegisterPackage("${CPM_ARGS_NAME}" "${CPM_ARGS_VERSION}")
+
+  if(DEFINED CPM_ARGS_GIT_TAG)
+    set(PACKAGE_INFO "${CPM_ARGS_GIT_TAG}")
+  elseif(DEFINED CPM_ARGS_SOURCE_DIR)
+    set(PACKAGE_INFO "${CPM_ARGS_SOURCE_DIR}")
+  else()
+    set(PACKAGE_INFO "${CPM_ARGS_VERSION}")
+  endif()
+
+  if(DEFINED FETCHCONTENT_BASE_DIR)
+    # respect user's FETCHCONTENT_BASE_DIR if set
+    set(CPM_FETCHCONTENT_BASE_DIR ${FETCHCONTENT_BASE_DIR})
+  else()
+    set(CPM_FETCHCONTENT_BASE_DIR ${CMAKE_BINARY_DIR}/_deps)
+  endif()
+
+  if(DEFINED CPM_ARGS_DOWNLOAD_COMMAND)
+    list(APPEND CPM_ARGS_UNPARSED_ARGUMENTS DOWNLOAD_COMMAND ${CPM_ARGS_DOWNLOAD_COMMAND})
+  elseif(DEFINED CPM_ARGS_SOURCE_DIR)
+    list(APPEND CPM_ARGS_UNPARSED_ARGUMENTS SOURCE_DIR ${CPM_ARGS_SOURCE_DIR})
+  elseif(CPM_SOURCE_CACHE AND NOT CPM_ARGS_NO_CACHE)
+    string(TOLOWER ${CPM_ARGS_NAME} lower_case_name)
+    set(origin_parameters ${CPM_ARGS_UNPARSED_ARGUMENTS})
+    list(SORT origin_parameters)
+    if(CPM_USE_NAMED_CACHE_DIRECTORIES)
+      string(SHA1 origin_hash "${origin_parameters};NEW_CACHE_STRUCTURE_TAG")
+      set(download_directory ${CPM_SOURCE_CACHE}/${lower_case_name}/${origin_hash}/${CPM_ARGS_NAME})
+    else()
+      string(SHA1 origin_hash "${origin_parameters}")
+      set(download_directory ${CPM_SOURCE_CACHE}/${lower_case_name}/${origin_hash})
+    endif()
+    # Expand `download_directory` relative path. This is important because EXISTS doesn't work for
+    # relative paths.
+    get_filename_component(download_directory ${download_directory} ABSOLUTE)
+    list(APPEND CPM_ARGS_UNPARSED_ARGUMENTS SOURCE_DIR ${download_directory})
+    if(EXISTS ${download_directory})
+      # avoid FetchContent modules to improve performance
+      set(${CPM_ARGS_NAME}_BINARY_DIR ${CPM_FETCHCONTENT_BASE_DIR}/${lower_case_name}-build)
+      set(${CPM_ARGS_NAME}_ADDED YES)
+      set(${CPM_ARGS_NAME}_SOURCE_DIR ${download_directory})
+
+      if(DEFINED CPM_ARGS_GIT_TAG)
+        # warn if cache has been changed since checkout
+        cpm_check_git_working_dir_is_clean(${download_directory} ${CPM_ARGS_GIT_TAG} IS_CLEAN)
+        if(NOT ${IS_CLEAN})
+          message(WARNING "Cache for ${CPM_ARGS_NAME} (${download_directory}) is dirty")
+        endif()
+      endif()
+
+      cpm_add_subdirectory(
+        "${CPM_ARGS_NAME}" "${DOWNLOAD_ONLY}"
+        "${${CPM_ARGS_NAME}_SOURCE_DIR}/${CPM_ARGS_SOURCE_SUBDIR}" "${${CPM_ARGS_NAME}_BINARY_DIR}"
+        "${CPM_ARGS_EXCLUDE_FROM_ALL}" "${CPM_ARGS_OPTIONS}"
+      )
+      set(CPM_SKIP_FETCH TRUE)
+      set(PACKAGE_INFO "${PACKAGE_INFO} at ${download_directory}")
+    else()
+      # Enable shallow clone when GIT_TAG is not a commit hash. Our guess may not be accurate, but
+      # it should guarantee no commit hash get mis-detected.
+      if(NOT DEFINED CPM_ARGS_GIT_SHALLOW)
+        cpm_is_git_tag_commit_hash("${CPM_ARGS_GIT_TAG}" IS_HASH)
+        if(NOT ${IS_HASH})
+          list(APPEND CPM_ARGS_UNPARSED_ARGUMENTS GIT_SHALLOW TRUE)
+        endif()
+      endif()
+
+      # remove timestamps so CMake will re-download the dependency
+      file(REMOVE_RECURSE ${CPM_FETCHCONTENT_BASE_DIR}/${lower_case_name}-subbuild)
+      set(PACKAGE_INFO "${PACKAGE_INFO} to ${download_directory}")
+    endif()
+  endif()
+
+  cpm_create_module_file(${CPM_ARGS_NAME} "CPMAddPackage(${ARGN})")
+
+  if(CPM_PACKAGE_LOCK_ENABLED)
+    if((CPM_ARGS_VERSION AND NOT CPM_ARGS_SOURCE_DIR) OR CPM_INCLUDE_ALL_IN_PACKAGE_LOCK)
+      cpm_add_to_package_lock(${CPM_ARGS_NAME} "${ARGN}")
+    elseif(CPM_ARGS_SOURCE_DIR)
+      cpm_add_comment_to_package_lock(${CPM_ARGS_NAME} "local directory")
+    else()
+      cpm_add_comment_to_package_lock(${CPM_ARGS_NAME} "${ARGN}")
+    endif()
+  endif()
+
+  message(
+    STATUS "${CPM_INDENT} adding package ${CPM_ARGS_NAME}@${CPM_ARGS_VERSION} (${PACKAGE_INFO})"
+  )
+
+  if(NOT CPM_SKIP_FETCH)
+    cpm_declare_fetch(
+      "${CPM_ARGS_NAME}" "${CPM_ARGS_VERSION}" "${PACKAGE_INFO}" "${CPM_ARGS_UNPARSED_ARGUMENTS}"
+    )
+    cpm_fetch_package("${CPM_ARGS_NAME}" populated)
+    if(${populated})
+      cpm_add_subdirectory(
+        "${CPM_ARGS_NAME}" "${DOWNLOAD_ONLY}"
+        "${${CPM_ARGS_NAME}_SOURCE_DIR}/${CPM_ARGS_SOURCE_SUBDIR}" "${${CPM_ARGS_NAME}_BINARY_DIR}"
+        "${CPM_ARGS_EXCLUDE_FROM_ALL}" "${CPM_ARGS_OPTIONS}"
+      )
+    endif()
+    cpm_get_fetch_properties("${CPM_ARGS_NAME}")
+  endif()
+
+  set(${CPM_ARGS_NAME}_ADDED YES)
+  cpm_export_variables("${CPM_ARGS_NAME}")
+endfunction()
+
+# Fetch a previously declared package
+macro(CPMGetPackage Name)
+  if(DEFINED "CPM_DECLARATION_${Name}")
+    CPMAddPackage(NAME ${Name})
+  else()
+    message(SEND_ERROR "Cannot retrieve package ${Name}: no declaration available")
+  endif()
+endmacro()
+
+# export variables available to the caller to the parent scope expects ${CPM_ARGS_NAME} to be set
+macro(cpm_export_variables name)
+  set(${name}_SOURCE_DIR
+      "${${name}_SOURCE_DIR}"
+      PARENT_SCOPE
+  )
+  set(${name}_BINARY_DIR
+      "${${name}_BINARY_DIR}"
+      PARENT_SCOPE
+  )
+  set(${name}_ADDED
+      "${${name}_ADDED}"
+      PARENT_SCOPE
+  )
+endmacro()
+
+# declares a package, so that any call to CPMAddPackage for the package name will use these
+# arguments instead. Previous declarations will not be overriden.
+macro(CPMDeclarePackage Name)
+  if(NOT DEFINED "CPM_DECLARATION_${Name}")
+    set("CPM_DECLARATION_${Name}" "${ARGN}")
+  endif()
+endmacro()
+
+function(cpm_add_to_package_lock Name)
+  if(NOT CPM_DONT_CREATE_PACKAGE_LOCK)
+    cpm_prettify_package_arguments(PRETTY_ARGN false ${ARGN})
+    file(APPEND ${CPM_PACKAGE_LOCK_FILE} "# ${Name}\nCPMDeclarePackage(${Name}\n${PRETTY_ARGN})\n")
+  endif()
+endfunction()
+
+function(cpm_add_comment_to_package_lock Name)
+  if(NOT CPM_DONT_CREATE_PACKAGE_LOCK)
+    cpm_prettify_package_arguments(PRETTY_ARGN true ${ARGN})
+    file(APPEND ${CPM_PACKAGE_LOCK_FILE}
+         "# ${Name} (unversioned)\n# CPMDeclarePackage(${Name}\n${PRETTY_ARGN}#)\n"
+    )
+  endif()
+endfunction()
+
+# includes the package lock file if it exists and creates a target `cpm-write-package-lock` to
+# update it
+macro(CPMUsePackageLock file)
+  if(NOT CPM_DONT_CREATE_PACKAGE_LOCK)
+    get_filename_component(CPM_ABSOLUTE_PACKAGE_LOCK_PATH ${file} ABSOLUTE)
+    if(EXISTS ${CPM_ABSOLUTE_PACKAGE_LOCK_PATH})
+      include(${CPM_ABSOLUTE_PACKAGE_LOCK_PATH})
+    endif()
+    if(NOT TARGET cpm-update-package-lock)
+      add_custom_target(
+        cpm-update-package-lock COMMAND ${CMAKE_COMMAND} -E copy ${CPM_PACKAGE_LOCK_FILE}
+                                        ${CPM_ABSOLUTE_PACKAGE_LOCK_PATH}
+      )
+    endif()
+    set(CPM_PACKAGE_LOCK_ENABLED true)
+  endif()
+endmacro()
+
+# registers a package that has been added to CPM
+function(CPMRegisterPackage PACKAGE VERSION)
+  list(APPEND CPM_PACKAGES ${PACKAGE})
+  set(CPM_PACKAGES
+      ${CPM_PACKAGES}
+      CACHE INTERNAL ""
+  )
+  set("CPM_PACKAGE_${PACKAGE}_VERSION"
+      ${VERSION}
+      CACHE INTERNAL ""
+  )
+endfunction()
+
+# retrieve the current version of the package to ${OUTPUT}
+function(CPMGetPackageVersion PACKAGE OUTPUT)
+  set(${OUTPUT}
+      "${CPM_PACKAGE_${PACKAGE}_VERSION}"
+      PARENT_SCOPE
+  )
+endfunction()
+
+# declares a package in FetchContent_Declare
+function(cpm_declare_fetch PACKAGE VERSION INFO)
+  if(${CPM_DRY_RUN})
+    message(STATUS "${CPM_INDENT} package not declared (dry run)")
+    return()
+  endif()
+
+  FetchContent_Declare(${PACKAGE} ${ARGN})
+endfunction()
+
+# returns properties for a package previously defined by cpm_declare_fetch
+function(cpm_get_fetch_properties PACKAGE)
+  if(${CPM_DRY_RUN})
+    return()
+  endif()
+  FetchContent_GetProperties(${PACKAGE})
+  string(TOLOWER ${PACKAGE} lpackage)
+  set(${PACKAGE}_SOURCE_DIR
+      "${${lpackage}_SOURCE_DIR}"
+      PARENT_SCOPE
+  )
+  set(${PACKAGE}_BINARY_DIR
+      "${${lpackage}_BINARY_DIR}"
+      PARENT_SCOPE
+  )
+endfunction()
+
+# adds a package as a subdirectory if viable, according to provided options
+function(
+  cpm_add_subdirectory
+  PACKAGE
+  DOWNLOAD_ONLY
+  SOURCE_DIR
+  BINARY_DIR
+  EXCLUDE
+  OPTIONS
+)
+  if(NOT DOWNLOAD_ONLY AND EXISTS ${SOURCE_DIR}/CMakeLists.txt)
+    if(EXCLUDE)
+      set(addSubdirectoryExtraArgs EXCLUDE_FROM_ALL)
+    else()
+      set(addSubdirectoryExtraArgs "")
+    endif()
+    if(OPTIONS)
+      # the policy allows us to change options without caching
+      cmake_policy(SET CMP0077 NEW)
+      set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
+
+      foreach(OPTION ${OPTIONS})
+        cpm_parse_option(${OPTION})
+        set(${OPTION_KEY} ${OPTION_VALUE})
+      endforeach()
+    endif()
+    set(CPM_OLD_INDENT "${CPM_INDENT}")
+    set(CPM_INDENT "${CPM_INDENT} ${PACKAGE}:")
+    add_subdirectory(${SOURCE_DIR} ${BINARY_DIR} ${addSubdirectoryExtraArgs})
+    set(CPM_INDENT "${CPM_OLD_INDENT}")
+  endif()
+endfunction()
+
+# downloads a previously declared package via FetchContent and exports the variables
+# `${PACKAGE}_SOURCE_DIR` and `${PACKAGE}_BINARY_DIR` to the parent scope
+function(cpm_fetch_package PACKAGE populated)
+  set(${populated}
+      FALSE
+      PARENT_SCOPE
+  )
+  if(${CPM_DRY_RUN})
+    message(STATUS "${CPM_INDENT} package ${PACKAGE} not fetched (dry run)")
+    return()
+  endif()
+
+  FetchContent_GetProperties(${PACKAGE})
+
+  string(TOLOWER "${PACKAGE}" lower_case_name)
+
+  if(NOT ${lower_case_name}_POPULATED)
+    FetchContent_Populate(${PACKAGE})
+    set(${populated}
+        TRUE
+        PARENT_SCOPE
+    )
+  endif()
+
+  set(${PACKAGE}_SOURCE_DIR
+      ${${lower_case_name}_SOURCE_DIR}
+      PARENT_SCOPE
+  )
+  set(${PACKAGE}_BINARY_DIR
+      ${${lower_case_name}_BINARY_DIR}
+      PARENT_SCOPE
+  )
+endfunction()
+
+# splits a package option
+function(cpm_parse_option OPTION)
+  string(REGEX MATCH "^[^ ]+" OPTION_KEY ${OPTION})
+  string(LENGTH ${OPTION} OPTION_LENGTH)
+  string(LENGTH ${OPTION_KEY} OPTION_KEY_LENGTH)
+  if(OPTION_KEY_LENGTH STREQUAL OPTION_LENGTH)
+    # no value for key provided, assume user wants to set option to "ON"
+    set(OPTION_VALUE "ON")
+  else()
+    math(EXPR OPTION_KEY_LENGTH "${OPTION_KEY_LENGTH}+1")
+    string(SUBSTRING ${OPTION} "${OPTION_KEY_LENGTH}" "-1" OPTION_VALUE)
+  endif()
+  set(OPTION_KEY
+      "${OPTION_KEY}"
+      PARENT_SCOPE
+  )
+  set(OPTION_VALUE
+      "${OPTION_VALUE}"
+      PARENT_SCOPE
+  )
+endfunction()
+
+# guesses the package version from a git tag
+function(cpm_get_version_from_git_tag GIT_TAG RESULT)
+  string(LENGTH ${GIT_TAG} length)
+  if(length EQUAL 40)
+    # GIT_TAG is probably a git hash
+    set(${RESULT}
+        0
+        PARENT_SCOPE
+    )
+  else()
+    string(REGEX MATCH "v?([0123456789.]*).*" _ ${GIT_TAG})
+    set(${RESULT}
+        ${CMAKE_MATCH_1}
+        PARENT_SCOPE
+    )
+  endif()
+endfunction()
+
+# guesses if the git tag is a commit hash or an actual tag or a branch nane.
+function(cpm_is_git_tag_commit_hash GIT_TAG RESULT)
+  string(LENGTH "${GIT_TAG}" length)
+  # full hash has 40 characters, and short hash has at least 7 characters.
+  if(length LESS 7 OR length GREATER 40)
+    set(${RESULT}
+        0
+        PARENT_SCOPE
+    )
+  else()
+    if(${GIT_TAG} MATCHES "^[a-fA-F0-9]+$")
+      set(${RESULT}
+          1
+          PARENT_SCOPE
+      )
+    else()
+      set(${RESULT}
+          0
+          PARENT_SCOPE
+      )
+    endif()
+  endif()
+endfunction()
+
+function(cpm_prettify_package_arguments OUT_VAR IS_IN_COMMENT)
+  set(oneValueArgs
+      NAME
+      FORCE
+      VERSION
+      GIT_TAG
+      DOWNLOAD_ONLY
+      GITHUB_REPOSITORY
+      GITLAB_REPOSITORY
+      GIT_REPOSITORY
+      SOURCE_DIR
+      DOWNLOAD_COMMAND
+      FIND_PACKAGE_ARGUMENTS
+      NO_CACHE
+      GIT_SHALLOW
+  )
+  set(multiValueArgs OPTIONS)
+  cmake_parse_arguments(CPM_ARGS "" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+  foreach(oneArgName ${oneValueArgs})
+    if(DEFINED CPM_ARGS_${oneArgName})
+      if(${IS_IN_COMMENT})
+        string(APPEND PRETTY_OUT_VAR "#")
+      endif()
+      if(${oneArgName} STREQUAL "SOURCE_DIR")
+        string(REPLACE ${CMAKE_SOURCE_DIR} "\${CMAKE_SOURCE_DIR}" CPM_ARGS_${oneArgName}
+                       ${CPM_ARGS_${oneArgName}}
+        )
+      endif()
+      string(APPEND PRETTY_OUT_VAR "  ${oneArgName} ${CPM_ARGS_${oneArgName}}\n")
+    endif()
+  endforeach()
+  foreach(multiArgName ${multiValueArgs})
+    if(DEFINED CPM_ARGS_${multiArgName})
+      if(${IS_IN_COMMENT})
+        string(APPEND PRETTY_OUT_VAR "#")
+      endif()
+      string(APPEND PRETTY_OUT_VAR "  ${multiArgName}\n")
+      foreach(singleOption ${CPM_ARGS_${multiArgName}})
+        if(${IS_IN_COMMENT})
+          string(APPEND PRETTY_OUT_VAR "#")
+        endif()
+        string(APPEND PRETTY_OUT_VAR "    \"${singleOption}\"\n")
+      endforeach()
+    endif()
+  endforeach()
+
+  if(NOT "${CPM_ARGS_UNPARSED_ARGUMENTS}" STREQUAL "")
+    if(${IS_IN_COMMENT})
+      string(APPEND PRETTY_OUT_VAR "#")
+    endif()
+    string(APPEND PRETTY_OUT_VAR " ")
+    foreach(CPM_ARGS_UNPARSED_ARGUMENT ${CPM_ARGS_UNPARSED_ARGUMENTS})
+      string(APPEND PRETTY_OUT_VAR " ${CPM_ARGS_UNPARSED_ARGUMENT}")
+    endforeach()
+    string(APPEND PRETTY_OUT_VAR "\n")
+  endif()
+
+  set(${OUT_VAR}
+      ${PRETTY_OUT_VAR}
+      PARENT_SCOPE
+  )
+
+endfunction()

--- a/gi_core/compat/spiral_solver.cpp
+++ b/gi_core/compat/spiral_solver.cpp
@@ -52,6 +52,10 @@
 #include "image.h"
 #include "core_logger.h"
 
+//#ifdef _WIN32
+//    #include "windows.h"
+//#endif
+
 using namespace std;
 
 

--- a/gi_core/dispatch/data/allocation/fast_float_aligned_allocator_impl.cpp
+++ b/gi_core/dispatch/data/allocation/fast_float_aligned_allocator_impl.cpp
@@ -1,0 +1,83 @@
+#include <data/allocation/fast_float_aligned_allocator_impl.hpp>
+#include <data/allocation/aligned_allocator.hpp>
+
+#include <simdpp/simd.h>
+#include <simdpp/dispatch/get_arch_raw_cpuid.h>
+#define SIMDPP_USER_ARCH_INFO ::simdpp::get_arch_raw_cpuid()
+
+namespace yagit::core::data::detail
+{
+    namespace SIMDPP_ARCH_NAMESPACE
+    {
+        namespace detail
+        {
+            template<size_t VectorSize>
+            struct alignas(simdpp::float32<VectorSize>) aligned_float32_block
+            {
+                float block[VectorSize];
+            };
+
+            template<size_t VectorSize>
+            struct alignas(simdpp::float64<VectorSize>) aligned_float64_block
+            {
+                double block[VectorSize];
+            };
+
+            template<size_t VectorSize>
+            constexpr size_t blocks_count(size_t n)
+            {
+                return (n / VectorSize) + (n % VectorSize > 0 ? 1 : 0);
+            }
+        }
+
+        // -------- float32 --------
+
+        constexpr size_t float32_VectorSize = SIMDPP_FAST_FLOAT32_SIZE;
+        using float_block = detail::aligned_float32_block<float32_VectorSize>;
+
+        float* allocate_float32(size_t n)
+        {
+            return reinterpret_cast<float*>(new float_block[detail::blocks_count<float32_VectorSize>(n)]);
+        }
+        allocation_result<float*> allocate_at_least_float32(size_t n)
+        {
+            auto bcount = detail::blocks_count<float32_VectorSize>(n);
+            return { reinterpret_cast<float*>(new float_block[bcount]), bcount * float32_VectorSize };
+        }
+        void deallocate_float32(float* p, size_t n)
+        {
+            delete[] p;
+        }
+
+        // -------- float64 --------
+
+        constexpr size_t float64_VectorSize = SIMDPP_FAST_FLOAT64_SIZE;
+        using double_block = detail::aligned_float64_block<float64_VectorSize>;
+
+        double* allocate_float64(size_t n)
+        {
+            return reinterpret_cast<double*>(new double_block[detail::blocks_count<float64_VectorSize>(n)]);
+        }
+        allocation_result<double*> allocate_at_least_float64(size_t n)
+        {
+            auto bcount = detail::blocks_count<float64_VectorSize>(n);
+            return { reinterpret_cast<double*>(new double_block[bcount]), bcount * float64_VectorSize };
+        }
+        void deallocate_float64(double* p, size_t n)
+        {
+            delete[] p;
+        }
+    }
+
+    // -------- float32 --------
+
+    SIMDPP_MAKE_DISPATCHER((float*)(allocate_float32)((size_t)n));
+    SIMDPP_MAKE_DISPATCHER((allocation_result<float*>)(allocate_at_least_float32)((size_t)n));
+    SIMDPP_MAKE_DISPATCHER((void)(deallocate_float32)((float*)p, (size_t)n));
+
+    // -------- float64 --------
+
+    SIMDPP_MAKE_DISPATCHER((double*)(allocate_float64)((size_t)n));
+    SIMDPP_MAKE_DISPATCHER((allocation_result<double*>)(allocate_at_least_float64)((size_t)n));
+    SIMDPP_MAKE_DISPATCHER((void)(deallocate_float64)((double*)p, (size_t)n));
+}

--- a/gi_core/dispatch/data/allocation/fast_float_aligned_allocator_impl.cpp
+++ b/gi_core/dispatch/data/allocation/fast_float_aligned_allocator_impl.cpp
@@ -1,3 +1,9 @@
+// This file is a dynamic-dispatch file used by libsimdpp
+// http://p12tic.github.io/libsimdpp/v2.2-dev/libsimdpp/w/arch/dispatch.html
+// The is so long because of the fact that each of the function differ only
+// sligthly in arguments (float/double 1/2/3 dimensions) and cannot be 
+// simplified into a template function due to dynamic-dispatch limitations
+
 #include <data/allocation/fast_float_aligned_allocator_impl.hpp>
 #include <data/allocation/aligned_allocator.hpp>
 

--- a/gi_core/dispatch/math/vectorized/gamma_index_range_impl.cpp
+++ b/gi_core/dispatch/math/vectorized/gamma_index_range_impl.cpp
@@ -1,0 +1,594 @@
+#include <math/vectorized/gamma_index_range_impl.hpp>
+
+#include <simdpp/dispatch/get_arch_raw_cpuid.h>
+#define SIMDPP_USER_ARCH_INFO ::simdpp::get_arch_raw_cpuid()
+
+namespace yagit::core::math::vectorized::detail
+{
+	namespace SIMDPP_ARCH_NAMESPACE
+	{
+		// -------- float32 --------
+
+		constexpr size_t float32_VectorSize = SIMDPP_FAST_FLOAT32_SIZE;
+
+		error_code gamma_index_initialize_pass(view<float> gamma_index_output, view<float> gamma_index_output_end)
+		{
+			if (is_aligned_to<float32_VectorSize>(gamma_index_output))
+			{
+				return detail::gamma_index_initialize_pass<true, float32_VectorSize>(gamma_index_output, gamma_index_output_end);
+			}
+			else
+			{
+				return detail::gamma_index_initialize_pass<false, float32_VectorSize>(gamma_index_output, gamma_index_output_end);
+			}
+		}
+
+		error_code gamma_index_minimize_pass(
+			view<float> gamma_index_output, view<float> gamma_index_output_end,
+			const_view<float> reference_doses,
+			array<const_view<float>, 1> reference_coordinates,
+			const_view<float> target_doses, const_view<float> target_doses_end,
+			array<const_view<float>, 1> target_coordinates,
+			const local_gamma_index_params<float>& params)
+		{
+			if (is_aligned_to<float32_VectorSize>(gamma_index_output) &&
+				is_aligned_to<float32_VectorSize>(reference_doses) &&
+				is_aligned_to<float32_VectorSize>(reference_coordinates[0]) &&
+				is_aligned_to<float32_VectorSize>(target_doses) &&
+				is_aligned_to<float32_VectorSize>(target_coordinates[0])
+				)
+			{
+				return detail::gamma_index_minimize_pass<true, float32_VectorSize>(
+					gamma_index_output, gamma_index_output_end,
+					reference_doses,
+					reference_coordinates,
+					target_doses, target_doses_end,
+					target_coordinates,
+					params, std::make_index_sequence<1>());
+			}
+			else
+			{
+				return detail::gamma_index_minimize_pass<false, float32_VectorSize>(
+					gamma_index_output, gamma_index_output_end,
+					reference_doses,
+					reference_coordinates,
+					target_doses, target_doses_end,
+					target_coordinates,
+					params, std::make_index_sequence<1>());
+			}
+		}
+		error_code gamma_index_minimize_pass(
+			view<float> gamma_index_output, view<float> gamma_index_output_end,
+			const_view<float> reference_doses,
+			array<const_view<float>, 2> reference_coordinates,
+			const_view<float> target_doses, const_view<float> target_doses_end,
+			array<const_view<float>, 2> target_coordinates,
+			const local_gamma_index_params<float>& params)
+		{
+			if (is_aligned_to<float32_VectorSize>(gamma_index_output) &&
+				is_aligned_to<float32_VectorSize>(reference_doses) &&
+				is_aligned_to<float32_VectorSize>(reference_coordinates[0]) &&
+				is_aligned_to<float32_VectorSize>(reference_coordinates[1]) &&
+				is_aligned_to<float32_VectorSize>(target_doses) &&
+				is_aligned_to<float32_VectorSize>(target_coordinates[0]) &&
+				is_aligned_to<float32_VectorSize>(target_coordinates[1])
+				)
+			{
+				return detail::gamma_index_minimize_pass<true, float32_VectorSize>(
+					gamma_index_output, gamma_index_output_end,
+					reference_doses,
+					reference_coordinates,
+					target_doses, target_doses_end,
+					target_coordinates,
+					params, std::make_index_sequence<2>());
+			}
+			else
+			{
+				return detail::gamma_index_minimize_pass<false, float32_VectorSize>(
+					gamma_index_output, gamma_index_output_end,
+					reference_doses,
+					reference_coordinates,
+					target_doses, target_doses_end,
+					target_coordinates,
+					params, std::make_index_sequence<2>());
+			}
+		}
+		error_code gamma_index_minimize_pass(
+			view<float> gamma_index_output, view<float> gamma_index_output_end,
+			const_view<float> reference_doses,
+			array<const_view<float>, 3> reference_coordinates,
+			const_view<float> target_doses, const_view<float> target_doses_end,
+			array<const_view<float>, 3> target_coordinates,
+			const local_gamma_index_params<float>& params)
+		{
+			if (is_aligned_to<float32_VectorSize>(gamma_index_output) &&
+				is_aligned_to<float32_VectorSize>(reference_doses) &&
+				is_aligned_to<float32_VectorSize>(reference_coordinates[0]) &&
+				is_aligned_to<float32_VectorSize>(reference_coordinates[1]) &&
+				is_aligned_to<float32_VectorSize>(reference_coordinates[2]) &&
+				is_aligned_to<float32_VectorSize>(target_doses) &&
+				is_aligned_to<float32_VectorSize>(target_coordinates[0]) &&
+				is_aligned_to<float32_VectorSize>(target_coordinates[1]) &&
+				is_aligned_to<float32_VectorSize>(target_coordinates[2])
+				)
+			{
+				return detail::gamma_index_minimize_pass<true, float32_VectorSize>(
+					gamma_index_output, gamma_index_output_end,
+					reference_doses,
+					reference_coordinates,
+					target_doses, target_doses_end,
+					target_coordinates,
+					params, std::make_index_sequence<3>());
+			}
+			else
+			{
+				return detail::gamma_index_minimize_pass<false, float32_VectorSize>(
+					gamma_index_output, gamma_index_output_end,
+					reference_doses,
+					reference_coordinates,
+					target_doses, target_doses_end,
+					target_coordinates,
+					params, std::make_index_sequence<3>());
+			}
+		}
+		error_code gamma_index_minimize_pass(
+			view<float> gamma_index_output, view<float> gamma_index_output_end,
+			const_view<float> reference_doses,
+			array<const_view<float>, 1> reference_coordinates,
+			const_view<float> target_doses, const_view<float> target_doses_end,
+			array<const_view<float>, 1> target_coordinates,
+			const global_gamma_index_params<float>& params)
+		{
+			if (is_aligned_to<float32_VectorSize>(gamma_index_output) &&
+				is_aligned_to<float32_VectorSize>(reference_doses) &&
+				is_aligned_to<float32_VectorSize>(reference_coordinates[0]) &&
+				is_aligned_to<float32_VectorSize>(target_doses) &&
+				is_aligned_to<float32_VectorSize>(target_coordinates[0])
+				)
+			{
+				return detail::gamma_index_minimize_pass<true, float32_VectorSize>(
+					gamma_index_output, gamma_index_output_end,
+					reference_doses,
+					reference_coordinates,
+					target_doses, target_doses_end,
+					target_coordinates,
+					params, std::make_index_sequence<1>());
+			}
+			else
+			{
+				return detail::gamma_index_minimize_pass<false, float32_VectorSize>(
+					gamma_index_output, gamma_index_output_end,
+					reference_doses,
+					reference_coordinates,
+					target_doses, target_doses_end,
+					target_coordinates,
+					params, std::make_index_sequence<1>());
+			}
+		}
+		error_code gamma_index_minimize_pass(
+			view<float> gamma_index_output, view<float> gamma_index_output_end,
+			const_view<float> reference_doses,
+			array<const_view<float>, 2> reference_coordinates,
+			const_view<float> target_doses, const_view<float> target_doses_end,
+			array<const_view<float>, 2> target_coordinates,
+			const global_gamma_index_params<float>& params)
+		{
+			if (is_aligned_to<float32_VectorSize>(gamma_index_output) &&
+				is_aligned_to<float32_VectorSize>(reference_doses) &&
+				is_aligned_to<float32_VectorSize>(reference_coordinates[0]) &&
+				is_aligned_to<float32_VectorSize>(reference_coordinates[1]) &&
+				is_aligned_to<float32_VectorSize>(target_doses) &&
+				is_aligned_to<float32_VectorSize>(target_coordinates[0]) &&
+				is_aligned_to<float32_VectorSize>(target_coordinates[1])
+				)
+			{
+				return detail::gamma_index_minimize_pass<true, float32_VectorSize>(
+					gamma_index_output, gamma_index_output_end,
+					reference_doses,
+					reference_coordinates,
+					target_doses, target_doses_end,
+					target_coordinates,
+					params, std::make_index_sequence<2>());
+			}
+			else
+			{
+				return detail::gamma_index_minimize_pass<false, float32_VectorSize>(
+					gamma_index_output, gamma_index_output_end,
+					reference_doses,
+					reference_coordinates,
+					target_doses, target_doses_end,
+					target_coordinates,
+					params, std::make_index_sequence<2>());
+			}
+		}
+		error_code gamma_index_minimize_pass(
+			view<float> gamma_index_output, view<float> gamma_index_output_end,
+			const_view<float> reference_doses,
+			array<const_view<float>, 3> reference_coordinates,
+			const_view<float> target_doses, const_view<float> target_doses_end,
+			array<const_view<float>, 3> target_coordinates,
+			const global_gamma_index_params<float>& params)
+		{
+			if (is_aligned_to<float32_VectorSize>(gamma_index_output) &&
+				is_aligned_to<float32_VectorSize>(reference_doses) &&
+				is_aligned_to<float32_VectorSize>(reference_coordinates[0]) &&
+				is_aligned_to<float32_VectorSize>(reference_coordinates[1]) &&
+				is_aligned_to<float32_VectorSize>(reference_coordinates[2]) &&
+				is_aligned_to<float32_VectorSize>(target_doses) &&
+				is_aligned_to<float32_VectorSize>(target_coordinates[0]) &&
+				is_aligned_to<float32_VectorSize>(target_coordinates[1]) &&
+				is_aligned_to<float32_VectorSize>(target_coordinates[2])
+				)
+			{
+				return detail::gamma_index_minimize_pass<true, float32_VectorSize>(
+					gamma_index_output, gamma_index_output_end,
+					reference_doses,
+					reference_coordinates,
+					target_doses, target_doses_end,
+					target_coordinates,
+					params, std::make_index_sequence<3>());
+			}
+			else
+			{
+				return detail::gamma_index_minimize_pass<false, float32_VectorSize>(
+					gamma_index_output, gamma_index_output_end,
+					reference_doses,
+					reference_coordinates,
+					target_doses, target_doses_end,
+					target_coordinates,
+					params, std::make_index_sequence<3>());
+			}
+		}
+
+		error_code gamma_index_finalize_pass(view<float> gamma_index_output, view<float> gamma_index_output_end)
+		{
+			if (is_aligned_to<float32_VectorSize>(gamma_index_output))
+			{
+				return detail::gamma_index_finalize_pass<true, float32_VectorSize>(gamma_index_output, gamma_index_output_end);
+			}
+			else
+			{
+				return detail::gamma_index_finalize_pass<false, float32_VectorSize>(gamma_index_output, gamma_index_output_end);
+			}
+		}
+
+		// -------- float64 --------
+
+		constexpr size_t float64_VectorSize = SIMDPP_FAST_FLOAT64_SIZE;
+
+		error_code gamma_index_initialize_pass(view<double> gamma_index_output, view<double> gamma_index_output_end)
+		{
+			if (is_aligned_to<float64_VectorSize>(gamma_index_output))
+			{
+				return detail::gamma_index_initialize_pass<true, float64_VectorSize>(gamma_index_output, gamma_index_output_end);
+			}
+			else
+			{
+				return detail::gamma_index_initialize_pass<false, float64_VectorSize>(gamma_index_output, gamma_index_output_end);
+			}
+		}
+
+		error_code gamma_index_minimize_pass(
+			view<double> gamma_index_output, view<double> gamma_index_output_end,
+			const_view<double> reference_doses,
+			array<const_view<double>, 1> reference_coordinates,
+			const_view<double> target_doses, const_view<double> target_doses_end,
+			array<const_view<double>, 1> target_coordinates,
+			const local_gamma_index_params<double>& params)
+		{
+			if (is_aligned_to<float64_VectorSize>(gamma_index_output) &&
+				is_aligned_to<float64_VectorSize>(reference_doses) &&
+				is_aligned_to<float64_VectorSize>(reference_coordinates[0]) &&
+				is_aligned_to<float64_VectorSize>(target_doses) &&
+				is_aligned_to<float64_VectorSize>(target_coordinates[0])
+				)
+			{
+				return detail::gamma_index_minimize_pass<true, float64_VectorSize>(
+					gamma_index_output, gamma_index_output_end,
+					reference_doses,
+					reference_coordinates,
+					target_doses, target_doses_end,
+					target_coordinates,
+					params, std::make_index_sequence<1>());
+			}
+			else
+			{
+				return detail::gamma_index_minimize_pass<false, float64_VectorSize>(
+					gamma_index_output, gamma_index_output_end,
+					reference_doses,
+					reference_coordinates,
+					target_doses, target_doses_end,
+					target_coordinates,
+					params, std::make_index_sequence<1>());
+			}
+		}
+		error_code gamma_index_minimize_pass(
+			view<double> gamma_index_output, view<double> gamma_index_output_end,
+			const_view<double> reference_doses,
+			array<const_view<double>, 2> reference_coordinates,
+			const_view<double> target_doses, const_view<double> target_doses_end,
+			array<const_view<double>, 2> target_coordinates,
+			const local_gamma_index_params<double>& params)
+		{
+			if (is_aligned_to<float64_VectorSize>(gamma_index_output) &&
+				is_aligned_to<float64_VectorSize>(reference_doses) &&
+				is_aligned_to<float64_VectorSize>(reference_coordinates[0]) &&
+				is_aligned_to<float64_VectorSize>(reference_coordinates[1]) &&
+				is_aligned_to<float64_VectorSize>(target_doses) &&
+				is_aligned_to<float64_VectorSize>(target_coordinates[0]) &&
+				is_aligned_to<float64_VectorSize>(target_coordinates[1])
+				)
+			{
+				return detail::gamma_index_minimize_pass<true, float64_VectorSize>(
+					gamma_index_output, gamma_index_output_end,
+					reference_doses,
+					reference_coordinates,
+					target_doses, target_doses_end,
+					target_coordinates,
+					params, std::make_index_sequence<2>());
+			}
+			else
+			{
+				return detail::gamma_index_minimize_pass<false, float64_VectorSize>(
+					gamma_index_output, gamma_index_output_end,
+					reference_doses,
+					reference_coordinates,
+					target_doses, target_doses_end,
+					target_coordinates,
+					params, std::make_index_sequence<2>());
+			}
+		}
+		error_code gamma_index_minimize_pass(
+			view<double> gamma_index_output, view<double> gamma_index_output_end,
+			const_view<double> reference_doses,
+			array<const_view<double>, 3> reference_coordinates,
+			const_view<double> target_doses, const_view<double> target_doses_end,
+			array<const_view<double>, 3> target_coordinates,
+			const local_gamma_index_params<double>& params)
+		{
+			if (is_aligned_to<float64_VectorSize>(gamma_index_output) &&
+				is_aligned_to<float64_VectorSize>(reference_doses) &&
+				is_aligned_to<float64_VectorSize>(reference_coordinates[0]) &&
+				is_aligned_to<float64_VectorSize>(reference_coordinates[1]) &&
+				is_aligned_to<float64_VectorSize>(reference_coordinates[2]) &&
+				is_aligned_to<float64_VectorSize>(target_doses) &&
+				is_aligned_to<float64_VectorSize>(target_coordinates[0]) &&
+				is_aligned_to<float64_VectorSize>(target_coordinates[1]) &&
+				is_aligned_to<float64_VectorSize>(target_coordinates[2])
+				)
+			{
+				return detail::gamma_index_minimize_pass<true, float64_VectorSize>(
+					gamma_index_output, gamma_index_output_end,
+					reference_doses,
+					reference_coordinates,
+					target_doses, target_doses_end,
+					target_coordinates,
+					params, std::make_index_sequence<3>());
+			}
+			else
+			{
+				return detail::gamma_index_minimize_pass<false, float64_VectorSize>(
+					gamma_index_output, gamma_index_output_end,
+					reference_doses,
+					reference_coordinates,
+					target_doses, target_doses_end,
+					target_coordinates,
+					params, std::make_index_sequence<3>());
+			}
+		}
+		error_code gamma_index_minimize_pass(
+			view<double> gamma_index_output, view<double> gamma_index_output_end,
+			const_view<double> reference_doses,
+			array<const_view<double>, 1> reference_coordinates,
+			const_view<double> target_doses, const_view<double> target_doses_end,
+			array<const_view<double>, 1> target_coordinates,
+			const global_gamma_index_params<double>& params)
+		{
+			if (is_aligned_to<float64_VectorSize>(gamma_index_output) &&
+				is_aligned_to<float64_VectorSize>(reference_doses) &&
+				is_aligned_to<float64_VectorSize>(reference_coordinates[0]) &&
+				is_aligned_to<float64_VectorSize>(target_doses) &&
+				is_aligned_to<float64_VectorSize>(target_coordinates[0])
+				)
+			{
+				return detail::gamma_index_minimize_pass<true, float64_VectorSize>(
+					gamma_index_output, gamma_index_output_end,
+					reference_doses,
+					reference_coordinates,
+					target_doses, target_doses_end,
+					target_coordinates,
+					params, std::make_index_sequence<1>());
+			}
+			else
+			{
+				return detail::gamma_index_minimize_pass<false, float64_VectorSize>(
+					gamma_index_output, gamma_index_output_end,
+					reference_doses,
+					reference_coordinates,
+					target_doses, target_doses_end,
+					target_coordinates,
+					params, std::make_index_sequence<1>());
+			}
+		}
+		error_code gamma_index_minimize_pass(
+			view<double> gamma_index_output, view<double> gamma_index_output_end,
+			const_view<double> reference_doses,
+			array<const_view<double>, 2> reference_coordinates,
+			const_view<double> target_doses, const_view<double> target_doses_end,
+			array<const_view<double>, 2> target_coordinates,
+			const global_gamma_index_params<double>& params)
+		{
+			if (is_aligned_to<float64_VectorSize>(gamma_index_output) &&
+				is_aligned_to<float64_VectorSize>(reference_doses) &&
+				is_aligned_to<float64_VectorSize>(reference_coordinates[0]) &&
+				is_aligned_to<float64_VectorSize>(reference_coordinates[1]) &&
+				is_aligned_to<float64_VectorSize>(target_doses) &&
+				is_aligned_to<float64_VectorSize>(target_coordinates[0]) &&
+				is_aligned_to<float64_VectorSize>(target_coordinates[1])
+				)
+			{
+				return detail::gamma_index_minimize_pass<true, float64_VectorSize>(
+					gamma_index_output, gamma_index_output_end,
+					reference_doses,
+					reference_coordinates,
+					target_doses, target_doses_end,
+					target_coordinates,
+					params, std::make_index_sequence<2>());
+			}
+			else
+			{
+				return detail::gamma_index_minimize_pass<false, float64_VectorSize>(
+					gamma_index_output, gamma_index_output_end,
+					reference_doses,
+					reference_coordinates,
+					target_doses, target_doses_end,
+					target_coordinates,
+					params, std::make_index_sequence<2>());
+			}
+		}
+		error_code gamma_index_minimize_pass(
+			view<double> gamma_index_output, view<double> gamma_index_output_end,
+			const_view<double> reference_doses,
+			array<const_view<double>, 3> reference_coordinates,
+			const_view<double> target_doses, const_view<double> target_doses_end,
+			array<const_view<double>, 3> target_coordinates,
+			const global_gamma_index_params<double>& params)
+		{
+			if (is_aligned_to<float64_VectorSize>(gamma_index_output) &&
+				is_aligned_to<float64_VectorSize>(reference_doses) &&
+				is_aligned_to<float64_VectorSize>(reference_coordinates[0]) &&
+				is_aligned_to<float64_VectorSize>(reference_coordinates[1]) &&
+				is_aligned_to<float64_VectorSize>(reference_coordinates[2]) &&
+				is_aligned_to<float64_VectorSize>(target_doses) &&
+				is_aligned_to<float64_VectorSize>(target_coordinates[0]) &&
+				is_aligned_to<float64_VectorSize>(target_coordinates[1]) &&
+				is_aligned_to<float64_VectorSize>(target_coordinates[2])
+				)
+			{
+				return detail::gamma_index_minimize_pass<true, float64_VectorSize>(
+					gamma_index_output, gamma_index_output_end,
+					reference_doses,
+					reference_coordinates,
+					target_doses, target_doses_end,
+					target_coordinates,
+					params, std::make_index_sequence<3>());
+			}
+			else
+			{
+				return detail::gamma_index_minimize_pass<false, float64_VectorSize>(
+					gamma_index_output, gamma_index_output_end,
+					reference_doses,
+					reference_coordinates,
+					target_doses, target_doses_end,
+					target_coordinates,
+					params, std::make_index_sequence<3>());
+			}
+		}
+
+		error_code gamma_index_finalize_pass(view<double> gamma_index_output, view<double> gamma_index_output_end)
+		{
+			if (is_aligned_to<float64_VectorSize>(gamma_index_output))
+			{
+				return detail::gamma_index_finalize_pass<true, float64_VectorSize>(gamma_index_output, gamma_index_output_end);
+			}
+			else
+			{
+				return detail::gamma_index_finalize_pass<false, float64_VectorSize>(gamma_index_output, gamma_index_output_end);
+			}
+		}
+	}
+
+	// -------- float32 --------
+
+	SIMDPP_MAKE_DISPATCHER((error_code)(gamma_index_initialize_pass)((view<float>)gamma_index_output, (view<float>)gamma_index_output_end));
+	SIMDPP_MAKE_DISPATCHER((error_code)(gamma_index_minimize_pass)
+		((view<float>)gamma_index_output, (view<float>) gamma_index_output_end,
+			(const_view<float>) reference_doses,
+			(array<const_view<float>, 1>) reference_coordinates,
+			(const_view<float>) target_doses, (const_view<float>) target_doses_end,
+			(array<const_view<float>, 1>) target_coordinates,
+			(const local_gamma_index_params<float>&) params));
+	SIMDPP_MAKE_DISPATCHER((error_code)(gamma_index_minimize_pass)
+		((view<float>)gamma_index_output, (view<float>) gamma_index_output_end,
+			(const_view<float>) reference_doses,
+			(array<const_view<float>, 2>) reference_coordinates,
+			(const_view<float>) target_doses, (const_view<float>) target_doses_end,
+			(array<const_view<float>, 2>) target_coordinates,
+			(const local_gamma_index_params<float>&) params));
+	SIMDPP_MAKE_DISPATCHER((error_code)(gamma_index_minimize_pass)
+		((view<float>)gamma_index_output, (view<float>) gamma_index_output_end,
+			(const_view<float>) reference_doses,
+			(array<const_view<float>, 3>) reference_coordinates,
+			(const_view<float>) target_doses, (const_view<float>) target_doses_end,
+			(array<const_view<float>, 3>) target_coordinates,
+			(const local_gamma_index_params<float>&) params));
+	SIMDPP_MAKE_DISPATCHER((error_code)(gamma_index_minimize_pass)
+		((view<float>)gamma_index_output, (view<float>) gamma_index_output_end,
+			(const_view<float>) reference_doses,
+			(array<const_view<float>, 1>) reference_coordinates,
+			(const_view<float>) target_doses, (const_view<float>) target_doses_end,
+			(array<const_view<float>, 1>) target_coordinates,
+			(const global_gamma_index_params<float>&) params));
+	SIMDPP_MAKE_DISPATCHER((error_code)(gamma_index_minimize_pass)
+		((view<float>)gamma_index_output, (view<float>) gamma_index_output_end,
+			(const_view<float>) reference_doses,
+			(array<const_view<float>, 2>) reference_coordinates,
+			(const_view<float>) target_doses, (const_view<float>) target_doses_end,
+			(array<const_view<float>, 2>) target_coordinates,
+			(const global_gamma_index_params<float>&) params));
+	SIMDPP_MAKE_DISPATCHER((error_code)(gamma_index_minimize_pass)
+		((view<float>)gamma_index_output, (view<float>) gamma_index_output_end,
+			(const_view<float>) reference_doses,
+			(array<const_view<float>, 3>) reference_coordinates,
+			(const_view<float>) target_doses, (const_view<float>) target_doses_end,
+			(array<const_view<float>, 3>) target_coordinates,
+			(const global_gamma_index_params<float>&) params));
+	SIMDPP_MAKE_DISPATCHER((error_code)(gamma_index_finalize_pass)((view<float>)gamma_index_output, (view<float>)gamma_index_output_end));
+
+	// -------- float64 --------
+
+	SIMDPP_MAKE_DISPATCHER((error_code)(gamma_index_initialize_pass)((view<double>)gamma_index_output, (view<double>)gamma_index_output_end));
+	SIMDPP_MAKE_DISPATCHER((error_code)(gamma_index_minimize_pass)
+		((view<double>)gamma_index_output, (view<double>) gamma_index_output_end,
+			(const_view<double>) reference_doses,
+			(array<const_view<double>, 1>) reference_coordinates,
+			(const_view<double>) target_doses, (const_view<double>) target_doses_end,
+			(array<const_view<double>, 1>) target_coordinates,
+			(const local_gamma_index_params<double>&) params));
+	SIMDPP_MAKE_DISPATCHER((error_code)(gamma_index_minimize_pass)
+		((view<double>)gamma_index_output, (view<double>) gamma_index_output_end,
+			(const_view<double>) reference_doses,
+			(array<const_view<double>, 2>) reference_coordinates,
+			(const_view<double>) target_doses, (const_view<double>) target_doses_end,
+			(array<const_view<double>, 2>) target_coordinates,
+			(const local_gamma_index_params<double>&) params));
+	SIMDPP_MAKE_DISPATCHER((error_code)(gamma_index_minimize_pass)
+		((view<double>)gamma_index_output, (view<double>) gamma_index_output_end,
+			(const_view<double>) reference_doses,
+			(array<const_view<double>, 3>) reference_coordinates,
+			(const_view<double>) target_doses, (const_view<double>) target_doses_end,
+			(array<const_view<double>, 3>) target_coordinates,
+			(const local_gamma_index_params<double>&) params));
+	SIMDPP_MAKE_DISPATCHER((error_code)(gamma_index_minimize_pass)
+		((view<double>)gamma_index_output, (view<double>) gamma_index_output_end,
+			(const_view<double>) reference_doses,
+			(array<const_view<double>, 1>) reference_coordinates,
+			(const_view<double>) target_doses, (const_view<double>) target_doses_end,
+			(array<const_view<double>, 1>) target_coordinates,
+			(const global_gamma_index_params<double>&) params));
+	SIMDPP_MAKE_DISPATCHER((error_code)(gamma_index_minimize_pass)
+		((view<double>)gamma_index_output, (view<double>) gamma_index_output_end,
+			(const_view<double>) reference_doses,
+			(array<const_view<double>, 2>) reference_coordinates,
+			(const_view<double>) target_doses, (const_view<double>) target_doses_end,
+			(array<const_view<double>, 2>) target_coordinates,
+			(const global_gamma_index_params<double>&) params));
+	SIMDPP_MAKE_DISPATCHER((error_code)(gamma_index_minimize_pass)
+		((view<double>)gamma_index_output, (view<double>) gamma_index_output_end,
+			(const_view<double>) reference_doses,
+			(array<const_view<double>, 3>) reference_coordinates,
+			(const_view<double>) target_doses, (const_view<double>) target_doses_end,
+			(array<const_view<double>, 3>) target_coordinates,
+			(const global_gamma_index_params<double>&) params));
+	SIMDPP_MAKE_DISPATCHER((error_code)(gamma_index_finalize_pass)((view<double>)gamma_index_output, (view<double>)gamma_index_output_end));
+}

--- a/gi_core/dispatch/math/vectorized/gamma_index_range_impl.cpp
+++ b/gi_core/dispatch/math/vectorized/gamma_index_range_impl.cpp
@@ -1,3 +1,9 @@
+// This file is a dynamic-dispatch file used by libsimdpp
+// http://p12tic.github.io/libsimdpp/v2.2-dev/libsimdpp/w/arch/dispatch.html
+// The is so long because of the fact that each of the function differ only
+// sligthly in arguments (float/double 1/2/3 dimensions) and cannot be 
+// simplified into a template function due to dynamic-dispatch limitations
+
 #include <math/vectorized/gamma_index_range_impl.hpp>
 
 #include <simdpp/dispatch/get_arch_raw_cpuid.h>

--- a/gi_core/dispatch/math/vectorized/openmp/gamma_index_range_impl.cpp
+++ b/gi_core/dispatch/math/vectorized/openmp/gamma_index_range_impl.cpp
@@ -1,3 +1,12 @@
+// This file is a dynamic-dispatch file used by libsimdpp
+// http://p12tic.github.io/libsimdpp/v2.2-dev/libsimdpp/w/arch/dispatch.html
+// The is so long because of the fact that each of the function differ only
+// sligthly in arguments (float/double 1/2/3 dimensions) and cannot be 
+// simplified into a template function due to dynamic-dispatch limitations
+
+// File may seem similar to dispatch/math/vectorized/openmp/gamma_index_range_impl.cpp
+// however
+
 #include <math/vectorized/openmp/gamma_index_range_impl.hpp>
 
 #include <simdpp/dispatch/get_arch_raw_cpuid.h>

--- a/gi_core/dispatch/math/vectorized/openmp/gamma_index_range_impl.cpp
+++ b/gi_core/dispatch/math/vectorized/openmp/gamma_index_range_impl.cpp
@@ -1,0 +1,602 @@
+#include <math/vectorized/openmp/gamma_index_range_impl.hpp>
+
+#include <simdpp/dispatch/get_arch_raw_cpuid.h>
+#define SIMDPP_USER_ARCH_INFO ::simdpp::get_arch_raw_cpuid()
+
+namespace yagit::core::math::vectorized::openmp::detail
+{
+	namespace SIMDPP_ARCH_NAMESPACE
+	{
+		// -------- float32 --------
+
+		constexpr size_t float32_VectorSize = SIMDPP_FAST_FLOAT32_SIZE;
+
+		error_code gamma_index_initialize_pass(view<float> gamma_index_output, view<float> gamma_index_output_end)
+		{
+			if (is_aligned_to<float32_VectorSize>(gamma_index_output))
+			{
+				return detail::gamma_index_initialize_pass<true, float32_VectorSize>(gamma_index_output, gamma_index_output_end);
+			}
+			else
+			{
+				return detail::gamma_index_initialize_pass<false, float32_VectorSize>(gamma_index_output, gamma_index_output_end);
+			}
+		}
+
+		error_code gamma_index_minimize_pass(
+			view<float> gamma_index_output, view<float> gamma_index_output_end,
+			const_view<float> reference_doses,
+			array<const_view<float>, 1> reference_coordinates,
+			const_view<float> target_doses, const_view<float> target_doses_end,
+			array<const_view<float>, 1> target_coordinates,
+			const local_gamma_index_params<float>& params)
+		{
+			if (is_aligned_to<float32_VectorSize>(gamma_index_output) &&
+				is_aligned_to<float32_VectorSize>(reference_doses) &&
+				is_aligned_to<float32_VectorSize>(reference_coordinates[0]) &&
+				is_aligned_to<float32_VectorSize>(target_doses) &&
+				is_aligned_to<float32_VectorSize>(target_coordinates[0])
+				)
+			{
+				return detail::gamma_index_minimize_pass<true, float32_VectorSize>(
+					gamma_index_output, gamma_index_output_end,
+					reference_doses,
+					reference_coordinates,
+					target_doses, target_doses_end,
+					target_coordinates,
+					params, std::make_index_sequence<1>());
+			}
+			else
+			{
+				return detail::gamma_index_minimize_pass<false, float32_VectorSize>(
+					gamma_index_output, gamma_index_output_end,
+					reference_doses,
+					reference_coordinates,
+					target_doses, target_doses_end,
+					target_coordinates,
+					params, std::make_index_sequence<1>());
+			}
+		}
+		error_code gamma_index_minimize_pass(
+			view<float> gamma_index_output, view<float> gamma_index_output_end,
+			const_view<float> reference_doses,
+			array<const_view<float>, 2> reference_coordinates,
+			const_view<float> target_doses, const_view<float> target_doses_end,
+			array<const_view<float>, 2> target_coordinates,
+			const local_gamma_index_params<float>& params)
+		{
+			if (is_aligned_to<float32_VectorSize>(gamma_index_output) &&
+				is_aligned_to<float32_VectorSize>(reference_doses) &&
+				is_aligned_to<float32_VectorSize>(reference_coordinates[0]) &&
+				is_aligned_to<float32_VectorSize>(reference_coordinates[1]) &&
+				is_aligned_to<float32_VectorSize>(target_doses) &&
+				is_aligned_to<float32_VectorSize>(target_coordinates[0]) &&
+				is_aligned_to<float32_VectorSize>(target_coordinates[1])
+				)
+			{
+				return detail::gamma_index_minimize_pass<true, float32_VectorSize>(
+					gamma_index_output, gamma_index_output_end,
+					reference_doses,
+					reference_coordinates,
+					target_doses, target_doses_end,
+					target_coordinates,
+					params, std::make_index_sequence<2>());
+			}
+			else
+			{
+				return detail::gamma_index_minimize_pass<false, float32_VectorSize>(
+					gamma_index_output, gamma_index_output_end,
+					reference_doses,
+					reference_coordinates,
+					target_doses, target_doses_end,
+					target_coordinates,
+					params, std::make_index_sequence<2>());
+			}
+		}
+		error_code gamma_index_minimize_pass(
+			view<float> gamma_index_output, view<float> gamma_index_output_end,
+			const_view<float> reference_doses,
+			array<const_view<float>, 3> reference_coordinates,
+			const_view<float> target_doses, const_view<float> target_doses_end,
+			array<const_view<float>, 3> target_coordinates,
+			const local_gamma_index_params<float>& params)
+		{
+			{
+				if (is_aligned_to<float32_VectorSize>(gamma_index_output) &&
+					is_aligned_to<float32_VectorSize>(reference_doses) &&
+					is_aligned_to<float32_VectorSize>(reference_coordinates[0]) &&
+					is_aligned_to<float32_VectorSize>(reference_coordinates[1]) &&
+					is_aligned_to<float32_VectorSize>(reference_coordinates[2]) &&
+					is_aligned_to<float32_VectorSize>(target_doses) &&
+					is_aligned_to<float32_VectorSize>(target_coordinates[0]) &&
+					is_aligned_to<float32_VectorSize>(target_coordinates[1]) &&
+					is_aligned_to<float32_VectorSize>(target_coordinates[2])
+					)
+				{
+					return detail::gamma_index_minimize_pass<true, float32_VectorSize>(
+						gamma_index_output, gamma_index_output_end,
+						reference_doses,
+						reference_coordinates,
+						target_doses, target_doses_end,
+						target_coordinates,
+						params, std::make_index_sequence<3>());
+				}
+				else
+				{
+					return detail::gamma_index_minimize_pass<false, float32_VectorSize>(
+						gamma_index_output, gamma_index_output_end,
+						reference_doses,
+						reference_coordinates,
+						target_doses, target_doses_end,
+						target_coordinates,
+						params, std::make_index_sequence<3>());
+				}
+			}
+		}
+		error_code gamma_index_minimize_pass(
+			view<float> gamma_index_output, view<float> gamma_index_output_end,
+			const_view<float> reference_doses,
+			array<const_view<float>, 1> reference_coordinates,
+			const_view<float> target_doses, const_view<float> target_doses_end,
+			array<const_view<float>, 1> target_coordinates,
+			const global_gamma_index_params<float>& params)
+		{
+			if (is_aligned_to<float32_VectorSize>(gamma_index_output) &&
+				is_aligned_to<float32_VectorSize>(reference_doses) &&
+				is_aligned_to<float32_VectorSize>(reference_coordinates[0]) &&
+				is_aligned_to<float32_VectorSize>(target_doses) &&
+				is_aligned_to<float32_VectorSize>(target_coordinates[0])
+				)
+			{
+				return detail::gamma_index_minimize_pass<true, float32_VectorSize>(
+					gamma_index_output, gamma_index_output_end,
+					reference_doses,
+					reference_coordinates,
+					target_doses, target_doses_end,
+					target_coordinates,
+					params, std::make_index_sequence<1>());
+			}
+			else
+			{
+				return detail::gamma_index_minimize_pass<false, float32_VectorSize>(
+					gamma_index_output, gamma_index_output_end,
+					reference_doses,
+					reference_coordinates,
+					target_doses, target_doses_end,
+					target_coordinates,
+					params, std::make_index_sequence<1>());
+			}
+		}
+		error_code gamma_index_minimize_pass(
+			view<float> gamma_index_output, view<float> gamma_index_output_end,
+			const_view<float> reference_doses,
+			array<const_view<float>, 2> reference_coordinates,
+			const_view<float> target_doses, const_view<float> target_doses_end,
+			array<const_view<float>, 2> target_coordinates,
+			const global_gamma_index_params<float>& params)
+		{
+			if (is_aligned_to<float32_VectorSize>(gamma_index_output) &&
+				is_aligned_to<float32_VectorSize>(reference_doses) &&
+				is_aligned_to<float32_VectorSize>(reference_coordinates[0]) &&
+				is_aligned_to<float32_VectorSize>(reference_coordinates[1]) &&
+				is_aligned_to<float32_VectorSize>(target_doses) &&
+				is_aligned_to<float32_VectorSize>(target_coordinates[0]) &&
+				is_aligned_to<float32_VectorSize>(target_coordinates[1])
+				)
+			{
+				return detail::gamma_index_minimize_pass<true, float32_VectorSize>(
+					gamma_index_output, gamma_index_output_end,
+					reference_doses,
+					reference_coordinates,
+					target_doses, target_doses_end,
+					target_coordinates,
+					params, std::make_index_sequence<2>());
+			}
+			else
+			{
+				return detail::gamma_index_minimize_pass<false, float32_VectorSize>(
+					gamma_index_output, gamma_index_output_end,
+					reference_doses,
+					reference_coordinates,
+					target_doses, target_doses_end,
+					target_coordinates,
+					params, std::make_index_sequence<2>());
+			}
+		}
+		error_code gamma_index_minimize_pass(
+			view<float> gamma_index_output, view<float> gamma_index_output_end,
+			const_view<float> reference_doses,
+			array<const_view<float>, 3> reference_coordinates,
+			const_view<float> target_doses, const_view<float> target_doses_end,
+			array<const_view<float>, 3> target_coordinates,
+			const global_gamma_index_params<float>& params)
+		{
+			{
+				if (is_aligned_to<float32_VectorSize>(gamma_index_output) &&
+					is_aligned_to<float32_VectorSize>(reference_doses) &&
+					is_aligned_to<float32_VectorSize>(reference_coordinates[0]) &&
+					is_aligned_to<float32_VectorSize>(reference_coordinates[1]) &&
+					is_aligned_to<float32_VectorSize>(reference_coordinates[2]) &&
+					is_aligned_to<float32_VectorSize>(target_doses) &&
+					is_aligned_to<float32_VectorSize>(target_coordinates[0]) &&
+					is_aligned_to<float32_VectorSize>(target_coordinates[1]) &&
+					is_aligned_to<float32_VectorSize>(target_coordinates[2])
+					)
+				{
+					return detail::gamma_index_minimize_pass<true, float32_VectorSize>(
+						gamma_index_output, gamma_index_output_end,
+						reference_doses,
+						reference_coordinates,
+						target_doses, target_doses_end,
+						target_coordinates,
+						params, std::make_index_sequence<3>());
+				}
+				else
+				{
+					return detail::gamma_index_minimize_pass<false, float32_VectorSize>(
+						gamma_index_output, gamma_index_output_end,
+						reference_doses,
+						reference_coordinates,
+						target_doses, target_doses_end,
+						target_coordinates,
+						params, std::make_index_sequence<3>());
+				}
+			}
+		}
+
+		error_code gamma_index_finalize_pass(view<float> gamma_index_output, view<float> gamma_index_output_end)
+		{
+			if (is_aligned_to<float32_VectorSize>(gamma_index_output))
+			{
+				return detail::gamma_index_finalize_pass<true, float32_VectorSize>(gamma_index_output, gamma_index_output_end);
+			}
+			else
+			{
+				return detail::gamma_index_finalize_pass<false, float32_VectorSize>(gamma_index_output, gamma_index_output_end);
+			}
+		}
+
+		// -------- float64 --------
+
+		constexpr size_t float64_VectorSize = SIMDPP_FAST_FLOAT64_SIZE;
+
+		error_code gamma_index_initialize_pass(view<double> gamma_index_output, view<double> gamma_index_output_end)
+		{
+			if (is_aligned_to<float64_VectorSize>(gamma_index_output))
+			{
+				return detail::gamma_index_initialize_pass<true, float64_VectorSize>(gamma_index_output, gamma_index_output_end);
+			}
+			else
+			{
+				return detail::gamma_index_initialize_pass<false, float64_VectorSize>(gamma_index_output, gamma_index_output_end);
+			}
+		}
+
+		error_code gamma_index_minimize_pass(
+			view<double> gamma_index_output, view<double> gamma_index_output_end,
+			const_view<double> reference_doses,
+			array<const_view<double>, 1> reference_coordinates,
+			const_view<double> target_doses, const_view<double> target_doses_end,
+			array<const_view<double>, 1> target_coordinates,
+			const local_gamma_index_params<double>& params)
+		{
+			if (is_aligned_to<float64_VectorSize>(gamma_index_output) &&
+				is_aligned_to<float64_VectorSize>(reference_doses) &&
+				is_aligned_to<float64_VectorSize>(reference_coordinates[0]) &&
+				is_aligned_to<float64_VectorSize>(target_doses) &&
+				is_aligned_to<float64_VectorSize>(target_coordinates[0])
+				)
+			{
+				return detail::gamma_index_minimize_pass<true, float64_VectorSize>(
+					gamma_index_output, gamma_index_output_end,
+					reference_doses,
+					reference_coordinates,
+					target_doses, target_doses_end,
+					target_coordinates,
+					params, std::make_index_sequence<1>());
+			}
+			else
+			{
+				return detail::gamma_index_minimize_pass<false, float64_VectorSize>(
+					gamma_index_output, gamma_index_output_end,
+					reference_doses,
+					reference_coordinates,
+					target_doses, target_doses_end,
+					target_coordinates,
+					params, std::make_index_sequence<1>());
+			}
+		}
+		error_code gamma_index_minimize_pass(
+			view<double> gamma_index_output, view<double> gamma_index_output_end,
+			const_view<double> reference_doses,
+			array<const_view<double>, 2> reference_coordinates,
+			const_view<double> target_doses, const_view<double> target_doses_end,
+			array<const_view<double>, 2> target_coordinates,
+			const local_gamma_index_params<double>& params)
+		{
+			if (is_aligned_to<float64_VectorSize>(gamma_index_output) &&
+				is_aligned_to<float64_VectorSize>(reference_doses) &&
+				is_aligned_to<float64_VectorSize>(reference_coordinates[0]) &&
+				is_aligned_to<float64_VectorSize>(reference_coordinates[1]) &&
+				is_aligned_to<float64_VectorSize>(target_doses) &&
+				is_aligned_to<float64_VectorSize>(target_coordinates[0]) &&
+				is_aligned_to<float64_VectorSize>(target_coordinates[1])
+				)
+			{
+				return detail::gamma_index_minimize_pass<true, float64_VectorSize>(
+					gamma_index_output, gamma_index_output_end,
+					reference_doses,
+					reference_coordinates,
+					target_doses, target_doses_end,
+					target_coordinates,
+					params, std::make_index_sequence<2>());
+			}
+			else
+			{
+				return detail::gamma_index_minimize_pass<false, float64_VectorSize>(
+					gamma_index_output, gamma_index_output_end,
+					reference_doses,
+					reference_coordinates,
+					target_doses, target_doses_end,
+					target_coordinates,
+					params, std::make_index_sequence<2>());
+			}
+		}
+		error_code gamma_index_minimize_pass(
+			view<double> gamma_index_output, view<double> gamma_index_output_end,
+			const_view<double> reference_doses,
+			array<const_view<double>, 3> reference_coordinates,
+			const_view<double> target_doses, const_view<double> target_doses_end,
+			array<const_view<double>, 3> target_coordinates,
+			const local_gamma_index_params<double>& params)
+		{
+			{
+				if (is_aligned_to<float64_VectorSize>(gamma_index_output) &&
+					is_aligned_to<float64_VectorSize>(reference_doses) &&
+					is_aligned_to<float64_VectorSize>(reference_coordinates[0]) &&
+					is_aligned_to<float64_VectorSize>(reference_coordinates[1]) &&
+					is_aligned_to<float64_VectorSize>(reference_coordinates[2]) &&
+					is_aligned_to<float64_VectorSize>(target_doses) &&
+					is_aligned_to<float64_VectorSize>(target_coordinates[0]) &&
+					is_aligned_to<float64_VectorSize>(target_coordinates[1]) &&
+					is_aligned_to<float64_VectorSize>(target_coordinates[2])
+					)
+				{
+					return detail::gamma_index_minimize_pass<true, float64_VectorSize>(
+						gamma_index_output, gamma_index_output_end,
+						reference_doses,
+						reference_coordinates,
+						target_doses, target_doses_end,
+						target_coordinates,
+						params, std::make_index_sequence<3>());
+				}
+				else
+				{
+					return detail::gamma_index_minimize_pass<false, float64_VectorSize>(
+						gamma_index_output, gamma_index_output_end,
+						reference_doses,
+						reference_coordinates,
+						target_doses, target_doses_end,
+						target_coordinates,
+						params, std::make_index_sequence<3>());
+				}
+			}
+		}
+		error_code gamma_index_minimize_pass(
+			view<double> gamma_index_output, view<double> gamma_index_output_end,
+			const_view<double> reference_doses,
+			array<const_view<double>, 1> reference_coordinates,
+			const_view<double> target_doses, const_view<double> target_doses_end,
+			array<const_view<double>, 1> target_coordinates,
+			const global_gamma_index_params<double>& params)
+		{
+			if (is_aligned_to<float64_VectorSize>(gamma_index_output) &&
+				is_aligned_to<float64_VectorSize>(reference_doses) &&
+				is_aligned_to<float64_VectorSize>(reference_coordinates[0]) &&
+				is_aligned_to<float64_VectorSize>(target_doses) &&
+				is_aligned_to<float64_VectorSize>(target_coordinates[0])
+				)
+			{
+				return detail::gamma_index_minimize_pass<true, float64_VectorSize>(
+					gamma_index_output, gamma_index_output_end,
+					reference_doses,
+					reference_coordinates,
+					target_doses, target_doses_end,
+					target_coordinates,
+					params, std::make_index_sequence<1>());
+			}
+			else
+			{
+				return detail::gamma_index_minimize_pass<false, float64_VectorSize>(
+					gamma_index_output, gamma_index_output_end,
+					reference_doses,
+					reference_coordinates,
+					target_doses, target_doses_end,
+					target_coordinates,
+					params, std::make_index_sequence<1>());
+			}
+		}
+		error_code gamma_index_minimize_pass(
+			view<double> gamma_index_output, view<double> gamma_index_output_end,
+			const_view<double> reference_doses,
+			array<const_view<double>, 2> reference_coordinates,
+			const_view<double> target_doses, const_view<double> target_doses_end,
+			array<const_view<double>, 2> target_coordinates,
+			const global_gamma_index_params<double>& params)
+		{
+			if (is_aligned_to<float64_VectorSize>(gamma_index_output) &&
+				is_aligned_to<float64_VectorSize>(reference_doses) &&
+				is_aligned_to<float64_VectorSize>(reference_coordinates[0]) &&
+				is_aligned_to<float64_VectorSize>(reference_coordinates[1]) &&
+				is_aligned_to<float64_VectorSize>(target_doses) &&
+				is_aligned_to<float64_VectorSize>(target_coordinates[0]) &&
+				is_aligned_to<float64_VectorSize>(target_coordinates[1])
+				)
+			{
+				return detail::gamma_index_minimize_pass<true, float64_VectorSize>(
+					gamma_index_output, gamma_index_output_end,
+					reference_doses,
+					reference_coordinates,
+					target_doses, target_doses_end,
+					target_coordinates,
+					params, std::make_index_sequence<2>());
+			}
+			else
+			{
+				return detail::gamma_index_minimize_pass<false, float64_VectorSize>(
+					gamma_index_output, gamma_index_output_end,
+					reference_doses,
+					reference_coordinates,
+					target_doses, target_doses_end,
+					target_coordinates,
+					params, std::make_index_sequence<2>());
+			}
+		}
+		error_code gamma_index_minimize_pass(
+			view<double> gamma_index_output, view<double> gamma_index_output_end,
+			const_view<double> reference_doses,
+			array<const_view<double>, 3> reference_coordinates,
+			const_view<double> target_doses, const_view<double> target_doses_end,
+			array<const_view<double>, 3> target_coordinates,
+			const global_gamma_index_params<double>& params)
+		{
+			{
+				if (is_aligned_to<float64_VectorSize>(gamma_index_output) &&
+					is_aligned_to<float64_VectorSize>(reference_doses) &&
+					is_aligned_to<float64_VectorSize>(reference_coordinates[0]) &&
+					is_aligned_to<float64_VectorSize>(reference_coordinates[1]) &&
+					is_aligned_to<float64_VectorSize>(reference_coordinates[2]) &&
+					is_aligned_to<float64_VectorSize>(target_doses) &&
+					is_aligned_to<float64_VectorSize>(target_coordinates[0]) &&
+					is_aligned_to<float64_VectorSize>(target_coordinates[1]) &&
+					is_aligned_to<float64_VectorSize>(target_coordinates[2])
+					)
+				{
+					return detail::gamma_index_minimize_pass<true, float64_VectorSize>(
+						gamma_index_output, gamma_index_output_end,
+						reference_doses,
+						reference_coordinates,
+						target_doses, target_doses_end,
+						target_coordinates,
+						params, std::make_index_sequence<3>());
+				}
+				else
+				{
+					return detail::gamma_index_minimize_pass<false, float64_VectorSize>(
+						gamma_index_output, gamma_index_output_end,
+						reference_doses,
+						reference_coordinates,
+						target_doses, target_doses_end,
+						target_coordinates,
+						params, std::make_index_sequence<3>());
+				}
+			}
+		}
+
+		error_code gamma_index_finalize_pass(view<double> gamma_index_output, view<double> gamma_index_output_end)
+		{
+			if (is_aligned_to<float64_VectorSize>(gamma_index_output))
+			{
+				return detail::gamma_index_finalize_pass<true, float64_VectorSize>(gamma_index_output, gamma_index_output_end);
+			}
+			else
+			{
+				return detail::gamma_index_finalize_pass<false, float64_VectorSize>(gamma_index_output, gamma_index_output_end);
+			}
+		}
+	}
+
+	// -------- float32 --------
+
+	SIMDPP_MAKE_DISPATCHER((error_code)(gamma_index_initialize_pass)((view<float>)gamma_index_output, (view<float>)gamma_index_output_end));
+	SIMDPP_MAKE_DISPATCHER((error_code)(gamma_index_minimize_pass)
+		((view<float>)gamma_index_output, (view<float>) gamma_index_output_end,
+			(const_view<float>) reference_doses,
+			(array<const_view<float>, 1>) reference_coordinates,
+			(const_view<float>) target_doses, (const_view<float>) target_doses_end,
+			(array<const_view<float>, 1>) target_coordinates,
+			(const local_gamma_index_params<float>&) params));
+	SIMDPP_MAKE_DISPATCHER((error_code)(gamma_index_minimize_pass)
+		((view<float>)gamma_index_output, (view<float>) gamma_index_output_end,
+			(const_view<float>) reference_doses,
+			(array<const_view<float>, 2>) reference_coordinates,
+			(const_view<float>) target_doses, (const_view<float>) target_doses_end,
+			(array<const_view<float>, 2>) target_coordinates,
+			(const local_gamma_index_params<float>&) params));
+	SIMDPP_MAKE_DISPATCHER((error_code)(gamma_index_minimize_pass)
+		((view<float>)gamma_index_output, (view<float>) gamma_index_output_end,
+			(const_view<float>) reference_doses,
+			(array<const_view<float>, 3>) reference_coordinates,
+			(const_view<float>) target_doses, (const_view<float>) target_doses_end,
+			(array<const_view<float>, 3>) target_coordinates,
+			(const local_gamma_index_params<float>&) params));
+	SIMDPP_MAKE_DISPATCHER((error_code)(gamma_index_minimize_pass)
+		((view<float>)gamma_index_output, (view<float>) gamma_index_output_end,
+			(const_view<float>) reference_doses,
+			(array<const_view<float>, 1>) reference_coordinates,
+			(const_view<float>) target_doses, (const_view<float>) target_doses_end,
+			(array<const_view<float>, 1>) target_coordinates,
+			(const global_gamma_index_params<float>&) params));
+	SIMDPP_MAKE_DISPATCHER((error_code)(gamma_index_minimize_pass)
+		((view<float>)gamma_index_output, (view<float>) gamma_index_output_end,
+			(const_view<float>) reference_doses,
+			(array<const_view<float>, 2>) reference_coordinates,
+			(const_view<float>) target_doses, (const_view<float>) target_doses_end,
+			(array<const_view<float>, 2>) target_coordinates,
+			(const global_gamma_index_params<float>&) params));
+	SIMDPP_MAKE_DISPATCHER((error_code)(gamma_index_minimize_pass)
+		((view<float>)gamma_index_output, (view<float>) gamma_index_output_end,
+			(const_view<float>) reference_doses,
+			(array<const_view<float>, 3>) reference_coordinates,
+			(const_view<float>) target_doses, (const_view<float>) target_doses_end,
+			(array<const_view<float>, 3>) target_coordinates,
+			(const global_gamma_index_params<float>&) params));
+	SIMDPP_MAKE_DISPATCHER((error_code)(gamma_index_finalize_pass)((view<float>)gamma_index_output, (view<float>)gamma_index_output_end));
+
+	// -------- float64 --------
+
+	SIMDPP_MAKE_DISPATCHER((error_code)(gamma_index_initialize_pass)((view<double>)gamma_index_output, (view<double>)gamma_index_output_end));
+	SIMDPP_MAKE_DISPATCHER((error_code)(gamma_index_minimize_pass)
+		((view<double>)gamma_index_output, (view<double>) gamma_index_output_end,
+			(const_view<double>) reference_doses,
+			(array<const_view<double>, 1>) reference_coordinates,
+			(const_view<double>) target_doses, (const_view<double>) target_doses_end,
+			(array<const_view<double>, 1>) target_coordinates,
+			(const local_gamma_index_params<double>&) params));
+	SIMDPP_MAKE_DISPATCHER((error_code)(gamma_index_minimize_pass)
+		((view<double>)gamma_index_output, (view<double>) gamma_index_output_end,
+			(const_view<double>) reference_doses,
+			(array<const_view<double>, 2>) reference_coordinates,
+			(const_view<double>) target_doses, (const_view<double>) target_doses_end,
+			(array<const_view<double>, 2>) target_coordinates,
+			(const local_gamma_index_params<double>&) params));
+	SIMDPP_MAKE_DISPATCHER((error_code)(gamma_index_minimize_pass)
+		((view<double>)gamma_index_output, (view<double>) gamma_index_output_end,
+			(const_view<double>) reference_doses,
+			(array<const_view<double>, 3>) reference_coordinates,
+			(const_view<double>) target_doses, (const_view<double>) target_doses_end,
+			(array<const_view<double>, 3>) target_coordinates,
+			(const local_gamma_index_params<double>&) params));
+	SIMDPP_MAKE_DISPATCHER((error_code)(gamma_index_minimize_pass)
+		((view<double>)gamma_index_output, (view<double>) gamma_index_output_end,
+			(const_view<double>) reference_doses,
+			(array<const_view<double>, 1>) reference_coordinates,
+			(const_view<double>) target_doses, (const_view<double>) target_doses_end,
+			(array<const_view<double>, 1>) target_coordinates,
+			(const global_gamma_index_params<double>&) params));
+	SIMDPP_MAKE_DISPATCHER((error_code)(gamma_index_minimize_pass)
+		((view<double>)gamma_index_output, (view<double>) gamma_index_output_end,
+			(const_view<double>) reference_doses,
+			(array<const_view<double>, 2>) reference_coordinates,
+			(const_view<double>) target_doses, (const_view<double>) target_doses_end,
+			(array<const_view<double>, 2>) target_coordinates,
+			(const global_gamma_index_params<double>&) params));
+	SIMDPP_MAKE_DISPATCHER((error_code)(gamma_index_minimize_pass)
+		((view<double>)gamma_index_output, (view<double>) gamma_index_output_end,
+			(const_view<double>) reference_doses,
+			(array<const_view<double>, 3>) reference_coordinates,
+			(const_view<double>) target_doses, (const_view<double>) target_doses_end,
+			(array<const_view<double>, 3>) target_coordinates,
+			(const global_gamma_index_params<double>&) params));
+	SIMDPP_MAKE_DISPATCHER((error_code)(gamma_index_finalize_pass)((view<double>)gamma_index_output, (view<double>)gamma_index_output_end));
+}

--- a/gi_core/include/common.hpp
+++ b/gi_core/include/common.hpp
@@ -4,7 +4,12 @@
 
 #include <system_error>
 #include <memory>
+#include <array>
 #include <optional>
+#include <algorithm>
+#include <functional>
+#include <variant>
+#include <numeric>
 
 #if(__cplusplus <= 202002L)
 #define ALLOCATE_AT_LEAST_NOT_DEFINED
@@ -14,16 +19,43 @@ namespace yagit::core
 {
 	using size_t = std::size_t;
 	using std::error_code;
+	using std::unique_ptr;
 	using std::shared_ptr;
 	using std::enable_if_t;
 	using std::optional;
 	using std::nullopt;
+	using std::array;
 	using std::true_type;
 	using std::false_type;
 	using std::declval;
+	using std::index_sequence;
+	using std::make_index_sequence;
+	using std::variant;
+	using std::numeric_limits;
 #ifndef ALLOCATE_AT_LEAST_NOT_DEFINED
 	using std::allocation_result;
 #endif
+
+	template<typename T>
+	using view = T*;
+
+	template<typename T>
+	using const_view = const T*;
+
+	template<size_t N>
+	constexpr bool is_power_of_two_v = N && !(N & (N - 1));
+
+	template<size_t ByteCount, typename ElementType, typename = std::enable_if_t<is_power_of_two_v<ByteCount>>>
+	bool is_aligned_to_bytes(const_view<ElementType> ptr)
+	{
+		return (reinterpret_cast<std::uintptr_t>(ptr) & ByteCount == 0);
+	}
+
+	template<size_t ElementCount, typename ElementType, typename = std::enable_if_t<is_power_of_two_v<ElementCount>>>
+	bool is_aligned_to(const_view<ElementType> ptr)
+	{
+		return is_aligned_to_bytes<sizeof(ElementType)* ElementCount>(ptr);
+	}
 
 	namespace data
 	{
@@ -35,7 +67,6 @@ namespace yagit::core
 			size_t count;
 		};
 #endif
-
 
 		namespace detail
 		{
@@ -72,10 +103,22 @@ namespace yagit::core
 		/// </summary>
 		/// <typeparam name="Dimensions">Dimensionality of the index offset</typeparam>
 		template<size_t Dimensions>
-		struct offset
+		struct offsets
 		{
-			size_t offsets[Dimensions];
+			size_t offset[Dimensions];
 		};
+
+		template<size_t Dimensions>
+		constexpr bool operator==(const offsets<Dimensions>& left, const offsets<Dimensions>& right) noexcept
+		{
+			return std::equal(std::begin(left.offset), std::end(left.offset), std::begin(right.offset), std::end(right.offset), std::equal_to<size_t>());
+		}
+
+		template<size_t Dimensions>
+		constexpr bool operator!=(const offsets<Dimensions>& left, const offsets<Dimensions>& right) noexcept
+		{
+			return !(left == right);
+		}
 
 		/// <summary>
 		/// <paramref name="Dimensions"/>-dimensional size
@@ -88,9 +131,21 @@ namespace yagit::core
 		};
 
 		template<size_t Dimensions>
+		constexpr bool operator==(const sizes<Dimensions>& left, const sizes<Dimensions>& right) noexcept
+		{
+			return std::equal(std::begin(left.sizes), std::end(left.sizes), std::begin(right.sizes), std::end(right.sizes), std::equal_to<size_t>());
+		}
+
+		template<size_t Dimensions>
+		constexpr bool operator!=(const sizes<Dimensions>& left, const sizes<Dimensions>& right) noexcept
+		{
+			return !(left == right);
+		}
+
+		template<size_t Dimensions>
 		constexpr size_t total_size(const sizes<Dimensions>& size)
 		{
-			return std::accumulate(dimension_sizes.begin(), dimension_sizes.end(), static_cast<size_t>(0), std::multiplies<size_t>());
+			return std::accumulate(std::begin(size.sizes), std::end(size.sizes), static_cast<size_t>(0), std::multiplies<size_t>());
 		}
 
 		/// <summary>
@@ -101,17 +156,39 @@ namespace yagit::core
 		template<size_t Dimensions>
 		struct data_region
 		{
-			offset<Dimensions> offset;
+			offsets<Dimensions> offset;
 			sizes<Dimensions> size;
 		};
 
-		struct order_element_t { size_t dimension; };
+		template<size_t Dimensions>
+		constexpr bool operator==(const data_region<Dimensions>& left, const data_region<Dimensions>& right) noexcept
+		{
+			return left.offset == right.offset && left.size == right.size;
+		}
+
+		template<size_t Dimensions>
+		constexpr bool operator!=(const data_region<Dimensions>& left, const data_region<Dimensions>& right) noexcept
+		{
+			return left.offset != right.offset || left.size != right.size;
+		}
+
+		struct order_element_t { size_t dimension_index; };
 
 		constexpr order_element_t dim_x { 0 };
 		constexpr order_element_t dim_y { 1 };
 		constexpr order_element_t dim_z { 2 };
 		template<size_t Dimension>
 		constexpr order_element_t dim = { Dimension };
+
+		constexpr bool operator==(const order_element_t& left, const order_element_t& right) noexcept
+		{
+			return left.dimension_index == right.dimension_index;
+		}
+
+		constexpr bool operator!=(const order_element_t& left, const order_element_t& right) noexcept
+		{
+			return left.dimension_index != right.dimension_index;
+		}
 
 		/// <summary>
 		/// Structure describing stored data format
@@ -120,12 +197,33 @@ namespace yagit::core
 		template<size_t Dimensions>
 		struct data_format
 		{
-			const std::array<order_element_t, Dimensions> order;
+			const array<order_element_t, Dimensions> order;
 		};
 
+		namespace detail
+		{
+			template<size_t Dimensions, size_t... I>
+			constexpr array<order_element_t, Dimensions> make_default_order(index_sequence<I...>)
+			{
+				return { dim<I>... };
+			}
+		}
+
 		template<size_t Dimensions>
-		constexpr data_format<Dimensions> cpp_multidimensional_array_format{ dim_x, dim_y, dim_z };
+		constexpr data_format<Dimensions> cpp_multidimensional_array_format{ detail::make_default_order<Dimensions>(make_index_sequence<Dimensions>()) };
 		template<size_t Dimensions>
-		constexpr data_format<Dimensions> default_format = cpp_multidimensional_array_format;
+		constexpr data_format<Dimensions> default_format = cpp_multidimensional_array_format<Dimensions>;
+
+		template<size_t Dimensions>
+		constexpr bool operator==(const data_format<Dimensions>& left, const data_format<Dimensions>& right) noexcept
+		{
+            return std::equal(std::begin(left.order), std::end(left.order), std::begin(right.order), std::end(right.order), std::equal_to<order_element_t>());
+		}
+
+		template<size_t Dimensions>
+		constexpr bool operator!=(const data_format<Dimensions>& left, const data_format<Dimensions>& right) noexcept
+		{
+			return !(left == right);
+		}
 	}
 }

--- a/gi_core/include/common.hpp
+++ b/gi_core/include/common.hpp
@@ -42,6 +42,7 @@ namespace yagit::core
 	template<typename T>
 	using const_view = const T*;
 
+	// https://iq.opengenus.org/detect-if-a-number-is-power-of-2-using-bitwise-operators/
 	template<size_t N>
 	constexpr bool is_power_of_two_v = N && !(N & (N - 1));
 

--- a/gi_core/include/data/allocation/aligned_allocator.hpp
+++ b/gi_core/include/data/allocation/aligned_allocator.hpp
@@ -1,0 +1,76 @@
+#pragma once
+
+#include <common.hpp>
+
+namespace yagit::core::data
+{
+	namespace detail
+	{
+		template<typename Type, size_t ElementMultiple, typename = enable_if_t<detail::is_power_of_two_v<ElementMultiple> && (alignof(Type)* ElementMultiple <= alignof(max_align_t))>>
+		struct alignas(alignof(Type)* ElementMultiple) aligned_block
+		{
+			Type block[ElementMultiple];
+		};
+	}
+
+    /// <summary>
+    /// Allocator providing a mean to allocate aligned memory to a boundary
+    /// defined by alignment requirement of the underyling type multiplied by
+    /// desired multiple of the element alignment requirement (must be a power of 2)
+    /// </summary>
+    /// <typeparam name="Type">Underlying type</typeparam>
+    /// <typeparam name="ElementMultiple">Multiplicity of element alignment requirement (must be a power of 2)</typeparam>
+	template<typename Type, size_t ElementMultiple, typename = enable_if_t<detail::is_power_of_two_v<ElementMultiple> && (alignof(Type)* ElementMultiple <= alignof(max_align_t))>>
+	class aligned_allocator 
+		: protected std::allocator<detail::aligned_block<Type, ElementMultiple>>
+	{
+	private:
+		using base = std::allocator<detail::aligned_block<Type, ElementMultiple>>;
+	public:
+		using value_type = Type;
+		using size_type = typename base::size_type;
+		using difference_type = typename base::difference_type;
+		using propagate_on_container_move_assignment = typename base::propagate_on_container_move_assignment;
+	public:
+		constexpr aligned_allocator() noexcept = default;
+		constexpr aligned_allocator(const aligned_allocator& other) noexcept = default;
+		constexpr aligned_allocator(aligned_allocator&& other) noexcept = default;
+	public:
+		constexpr aligned_allocator& operator=(const aligned_allocator& other) noexcept = default;
+		constexpr aligned_allocator& operator=(aligned_allocator&& other) noexcept = default;
+	public:
+		constexpr ~aligned_allocator() = default;
+	private:
+		constexpr size_type blocks_count(size_type n)
+		{
+			return (n / ElementMultiple) + (n % ElementMultiple > 0 ? 1 : 0);
+		}
+	public:
+		value_type* allocate(size_type n)
+		{
+			return reinterpret_cast<value_type*>(base::allocate(blocks_count(n)));
+		}
+		allocation_result<value_type*> allocate_at_least(size_type n)
+		{
+			auto bcount = blocks_count(n);
+			return { reinterpret_cast<value_type*>(base::allocate(bcount)), bcount * ElementMultiple };
+		}
+		void deallocate(value_type* p, size_type n)
+		{
+			base::deallocate(p, n);
+		}
+	public:
+		constexpr bool operator==(const aligned_allocator& other)
+		{
+			return base::operator==(other);
+		}
+		constexpr bool operator!=(const aligned_allocator& other)
+		{
+#if(__cplusplus < 202002L)
+			return base::operator!=(other);
+#else
+			return !operator==(other);
+#endif
+		}
+	};
+}

--- a/gi_core/include/data/allocation/fast_float_aligned_allocator.hpp
+++ b/gi_core/include/data/allocation/fast_float_aligned_allocator.hpp
@@ -1,0 +1,84 @@
+#pragma once
+
+#include <common.hpp>
+
+namespace yagit::core::data
+{
+    /// <summary>
+    /// Allocator providing a mean to allocate memory for storing
+    /// float32/64 data in such a way that math operations made on
+    /// them will not suffer from its memory placement.
+    /// If supplied type is not of float32/float64 type it default
+    /// to std::allocator
+    /// </summary>
+    /// <typeparam name="Type">Underlying type</typeparam>
+    template<typename Type>
+    class fast_float_aligned_allocator
+            : std::allocator<Type> // by default falls back to std::allocator
+    {
+    };
+
+    template<>
+    class fast_float_aligned_allocator<float>
+    {
+    public:
+        using value_type = float;
+        using size_type = size_t;
+        using difference_type = ptrdiff_t;
+        using propagate_on_container_move_assignment = std::true_type;
+    public:
+        constexpr fast_float_aligned_allocator() noexcept = default;
+        constexpr fast_float_aligned_allocator(const fast_float_aligned_allocator& other) noexcept = default;
+        constexpr fast_float_aligned_allocator(fast_float_aligned_allocator&& other) noexcept = default;
+    public:
+        constexpr fast_float_aligned_allocator& operator=(const fast_float_aligned_allocator& other) noexcept = default;
+        constexpr fast_float_aligned_allocator& operator=(fast_float_aligned_allocator&& other) noexcept = default;
+    public:
+        constexpr ~fast_float_aligned_allocator() = default;
+    public:
+        value_type* allocate(size_type n);
+        allocation_result<value_type*> allocate_at_least(size_type n);
+        void deallocate(value_type* p, size_type n);
+    public:
+        constexpr bool operator==(const fast_float_aligned_allocator& other)
+        {
+            return true;
+        }
+        constexpr bool operator!=(const fast_float_aligned_allocator& other)
+        {
+            return !operator==(other);
+        }
+    };
+
+    template<>
+    class fast_float_aligned_allocator<double>
+    {
+    public:
+        using value_type = double;
+        using size_type = size_t;
+        using difference_type = ptrdiff_t;
+        using propagate_on_container_move_assignment = std::true_type;
+    public:
+        constexpr fast_float_aligned_allocator() noexcept = default;
+        constexpr fast_float_aligned_allocator(const fast_float_aligned_allocator& other) noexcept = default;
+        constexpr fast_float_aligned_allocator(fast_float_aligned_allocator&& other) noexcept = default;
+    public:
+        constexpr fast_float_aligned_allocator& operator=(const fast_float_aligned_allocator& other) noexcept = default;
+        constexpr fast_float_aligned_allocator& operator=(fast_float_aligned_allocator&& other) noexcept = default;
+    public:
+        constexpr ~fast_float_aligned_allocator() = default;
+    public:
+        value_type* allocate(size_type n);
+        allocation_result<value_type*> allocate_at_least(size_type n);
+        void deallocate(value_type* p, size_type n);
+    public:
+        constexpr bool operator==(const fast_float_aligned_allocator& other)
+        {
+            return true;
+        }
+        constexpr bool operator!=(const fast_float_aligned_allocator& other)
+        {
+            return !operator==(other);
+        }
+    };
+}

--- a/gi_core/include/data/image/iimage.hpp
+++ b/gi_core/include/data/image/iimage.hpp
@@ -1,12 +1,12 @@
 #pragma once
 
 #include <common.hpp>
-#include <data/iimage_region.hpp>
+#include <data/image/iimage_region.hpp>
 
 namespace yagit::core::data
 {
 	/// <summary>
-	/// Interface representing whole (DICOM) image. Should not contain image data
+	/// Interface representing whole image. Should not contain image data
 	/// but rather handle to some image resource that can be loaded into memory
 	/// on demand
 	/// </summary>
@@ -14,9 +14,11 @@ namespace yagit::core::data
 	/// <typeparam name="Dimensions">Dimensionality of image data point storage</typeparam>
 	template<typename ElementType, size_t Dimensions>
 	class iimage
-		: public iimage_region<ElementType, Dimensions>
+		: public virtual iimage_region<ElementType, Dimensions>
 	{
 	public:
 		virtual ~iimage() override = default;
+	public:
+		virtual sizes<Dimensions> size() const = 0;
 	};
 }

--- a/gi_core/include/data/image/iimage_region.hpp
+++ b/gi_core/include/data/image/iimage_region.hpp
@@ -1,13 +1,12 @@
 #pragma once
 
 #include <common.hpp>
-#include <data/image_data.hpp>
-#include <data/image_coordinates.hpp>
+#include <data/image/image_data.hpp>
 
 namespace yagit::core::data
 {
 	/// <summary>
-	/// Interface representing region of (DICOM) image. Should not contain image data
+	/// Interface representing region of image. Should not contain image data
 	/// but rather be a handle to some image resource that can be loaded into memory
 	/// on demand
 	/// </summary>
@@ -19,11 +18,16 @@ namespace yagit::core::data
 	public:
 		virtual ~iimage_region() = default;
 	public:
-		std::unique_ptr<iimage_region<ElementType, Dimensions>> subregion(const data_region<Dimensions>& region) const
-		{
-			error_code ec;
-			return subregion(region, ec);
-		}
+		/// <summary></summary>
+		/// <returns>Preferred implementation format to load the data points</returns>
+		virtual data_format<Dimensions> preferred_data_format() const = 0;
+		
+		/// <summary>
+		/// <para>Region of original image represented by this iimage_region. (relative to iimage - not parent iimage_region) </para>
+		/// </summary>
+		/// <returns>Region of original image represented by this iimage_region.</returns>
+		virtual data_region<Dimensions> region() const noexcept = 0;
+
 		/// <summary>
 		/// <para>Obtains an iimage_region corresponding to provided subregion.</para>
 		/// <para>Provided subregion should be interpreted locally i.e subregion is a subregion of region()
@@ -37,13 +41,15 @@ namespace yagit::core::data
 		/// <param name="region">Subregion relative to region()</param>
 		/// <param name="ec">Error code</param>
 		/// <returns>iimage_region containing subregion defined by region</returns>
-		virtual std::unique_ptr<iimage_region<ElementType, Dimensions>> subregion(const data_region<Dimensions>& region, error_code& ec) const = 0;
-
-		/// <summary>
-		/// <para>Region of original image represented by this iimage_region. (relative to iimage - not parent iimage_region) </para>
-		/// </summary>
-		/// <returns>Region of original image represented by this iimage_region.</returns>
-		virtual data_region<Dimensions> region() const noexcept = 0;
+		unique_ptr<iimage_region<ElementType, Dimensions>> subregion(const data_region<Dimensions>& region, error_code& ec) const
+		{
+			return unique_ptr<iimage_region<ElementType, Dimensions>>(create_subregion(region, ec));
+		}
+		unique_ptr<iimage_region<ElementType, Dimensions>> subregion(const data_region<Dimensions>& region) const
+		{
+			error_code ec;
+			return subregion(region, ec);
+		}
 
 		/// <summary>
 		/// <para>Returns image slice along <paramref name="Dimension"/> axi at <paramref name="index"/></para>
@@ -55,12 +61,12 @@ namespace yagit::core::data
 		/// <param name="ec">Error code</param>
 		/// <returns>Lower dimensional slice of iimage_region</returns>
 		template<size_t Dimension, typename = std::enable_if_t<(Dimension > 1)>>
-		std::unique_ptr<iimage_region<ElementType, Dimensions - 1>> slice(size_t index, error_code& ec)
+		unique_ptr<iimage_region<ElementType, Dimensions - 1>> slice(size_t index, error_code& ec)
 		{
 			return slice(Dimension, index, ec);
 		}
 		template<size_t Dimension, typename = std::enable_if_t<(Dimension > 1)>>
-		std::unique_ptr<iimage_region<ElementType, Dimensions - 1>> slice(size_t index)
+		unique_ptr<iimage_region<ElementType, Dimensions - 1>> slice(size_t index)
 		{
 			error_code ec;
 			return slice<Dimension>(index, ec);
@@ -96,51 +102,6 @@ namespace yagit::core::data
 			error_code ec;
 			return load(format, allocator, ec);
 		}
-
-		// !! assumption about image coordinates type may be wrong as some image can have coordinates of type different
-		// to the data point type, this simplification that coordinate_type == data_point_type is strictly made to 
-		// unify all possible coordinate_types (to floating point type - ElementType) and simplify calculations that are using
-		// those coordinates as additional input along data points !!
-
-		/// <summary>
-		/// <para>Loads iimage_region image data point coordinates into memory buffer (image_coordinates)</para>
-		/// <para>iimage_region data point coordinats should be in the same order as corresponding data points</para>
-		/// <para>obtained by <see cref="iimage_region::load"/> provided they were obtained with the same data_format</para>
-		/// <para>TODO: describe and implement reasonable exception-less error handling</para>
-		/// </summary>
-		/// <typeparam name="Allocator">Allocator type to use for data storage allocation</typeparam>
-		/// <param name="format">: Data format in which data point coordinates should be loaded</param>
-		/// <param name="allocator">: Allocator to use for data storage allocation</param>
-		/// <param name="ec">Error code</param>
-		/// <returns>Loaded image data point coordinates into memory buffer (image_data)</returns>
-		template<size_t Dimension, typename Allocator = std::allocator<ElementType>, typename = std::enable_if_t<(Dimension < Dimensions)>>
-		optional<image_coordinates<ElementType, Dimensions>> load_coordinates(const data_format<Dimensions>& format, Allocator allocator, error_code& ec) const
-		{
-			size_t required_size = 0;
-
-			if (ec = load_coordinates(nullptr, format, required_size))
-				return nullopt;
-
-			auto storage = allocate_at_least_for_image_data(std::move(allocator), required_size);
-
-			if (ec = load_coordinates(storage.get(), Dimension, format, required_size))
-				return nullopt;
-
-			return image_coordinates(std::move(storage), region(), format, allocated_size);
-		}
-		template<size_t Dimension, typename Allocator = std::allocator<ElementType>, typename = std::enable_if_t<(Dimension < Dimensions)>>
-		optional<image_coordinates<ElementType, Dimensions>> load_coordinates(const data_format<Dimensions>& format, Allocator allocator) const
-		{
-			error_code ec;
-			return load_coordinates(format, allocator, ec);
-		}
-		
-		/// <summary>
-		/// <para>Implementable method responsible for data point coordinates saving</para>
-		/// </summary>
-		/// <param name="data">: Image data to be saved.</param>
-		/// <returns>Error code informing about error that occured during execution unless success</returns>
-		virtual error_code save(const image_data<ElementType, Dimensions>& data) = 0;
 	protected:
 		/// <summary>
 		/// <para>Implementable method responsible for data points loading</para>
@@ -155,19 +116,6 @@ namespace yagit::core::data
 		/// </param>
 		/// <returns>Error code informing about error that occured during execution unless success</returns>
 		virtual error_code load(ElementType* data_storage, const data_format<Dimensions>& format, size_t& required_size) const = 0;
-		/// <summary>
-		/// <para>Implementable method responsible for data point coordinates loading</para>
-		/// </summary>
-		/// <param name="data_storage">: Pointer to contiguous memory block to which data point coordinates should be loaded.</param>
-		/// <param name="format">: Format in which data point coordinates should be loaded. If data_storage is nullptr, this is argument is ignored.</param>
-		/// <param name="required_size">
-		/// : returns required size for data point coordinates loading imposed by implementation must 
-		/// be greater of equal to regular C array of type ElementType of size required to fit all data points in region().
-		/// If data_storage is nullptr, this argument returns implementation based required data points storage size.
-		/// Else is treated as an input informing about size of allocated storage, handling as input is implementation defined.
-		/// </param>
-		/// <returns>Error code informing about error that occured during execution unless success</returns>
-		virtual error_code load_coordinates(ElementType* data_storage, size_t dimension, const data_format<Dimensions>& format, size_t& required_size) const = 0;
 
 		/// <summary>
 		/// <para>Implementable method responsive for slicing iimage_region</para>
@@ -176,8 +124,23 @@ namespace yagit::core::data
 		/// <param name="index">: index along dimension-axi at which the slice should be taken</param>
 		/// <param name="ec">Error code</param>
 		/// <returns>Slice of iimage_region unless implementation error occured then nullptr</returns>
-		virtual std::unique_ptr<iimage_region<ElementType, Dimensions - 1>> slice(size_t dimension, size_t index, error_code& ec) const = 0;
-	private:
+		virtual unique_ptr<iimage_region<ElementType, Dimensions - 1>> slice(size_t dimension, size_t index, error_code& ec) const = 0;
+
+		/// <summary>
+		/// <para>Obtains an iimage_region corresponding to provided subregion.</para>
+		/// <para>Provided subregion should be interpreted locally i.e subregion is a subregion of region()
+		/// not whole image subregion</para>
+		/// <para>Can return null in four cases:</para>
+		/// <para> - provided region is bigger (in size) than region() </para>
+		/// <para> - provided region's offset is outside region() </para>
+		/// <para> - provided region is invalid i.e one of subregion sizes is 0</para>
+		/// <para> - implementation doesn't allow for taking subregions of this iimage_region</para>
+		/// </summary>
+		/// <param name="region">Subregion relative to region()</param>
+		/// <param name="ec">Error code</param>
+		/// <returns>transfers ownership of iimage_region containing subregion defined by region</returns>
+		virtual iimage_region<ElementType, Dimensions>* create_subregion(const data_region<Dimensions>& region, error_code& ec) const = 0;
+	protected:
 		template<typename Allocator>
 		static shared_ptr<ElementType[]> allocate_at_least_for_image_data(Allocator allocator, size_t& required_size)
 		{
@@ -187,7 +150,7 @@ namespace yagit::core::data
 				required_size = allocation_result.count;
 				return shared_ptr<ElementType[]>(
 					allocation_result.ptr,
-					[allocator, allocated_size = required_size](ElementType* ptr) { allocator.deallocate(ptr, allocated_size); },
+					[allocator, allocated_size = required_size](ElementType* ptr) mutable { allocator.deallocate(ptr, allocated_size); },
 					allocator
 				);
 			}
@@ -196,7 +159,7 @@ namespace yagit::core::data
 				auto memory = allocator.allocate(required_size);
 				return shared_ptr<ElementType[]>(
 					memory,
-					[allocator, allocated_size = required_size](ElementType* ptr) { allocator.deallocate(ptr, allocated_size); },
+					[allocator, allocated_size = required_size](ElementType* ptr) mutable { allocator.deallocate(ptr, allocated_size); },
 					allocator
 				);
 			}

--- a/gi_core/include/data/image/image_data.hpp
+++ b/gi_core/include/data/image/image_data.hpp
@@ -5,21 +5,6 @@
 
 namespace yagit::core::data
 {
-	namespace detail
-	{
-		template<size_t ByteCount, typename ElementType, typename = std::enable_if_t<detail::is_power_of_two_v<ByteCount>>>
-		constexpr bool is_aligned_to_bytes(const ElementType* ptr)
-		{
-			return (static_cast<std::uintptr_t>(_data) & ByteCount == 0);
-		}
-
-		template<size_t ElementCount, typename ElementType, typename = std::enable_if_t<detail::is_power_of_two_v<ElementCount>>>
-		constexpr bool is_aligned_to(const ElementType* ptr)
-		{
-			return is_aligned_to_bytes<sizeof(T)* ElementCount>(_data);
-		}
-	}
-
 	/// <summary>
 	/// Class encapsulating storage for image data points
 	/// </summary>
@@ -53,7 +38,7 @@ namespace yagit::core::data
 			const data_format<Dimensions>& data_format,
 			const size_t real_total_size
 		)
-			: _data(data.release())
+			: _data(data)
 			, _image_region(image_region)
 			, _data_format(data_format)
 			, _real_total_size(real_total_size)
@@ -62,7 +47,7 @@ namespace yagit::core::data
 	public:
 		/// <summary></summary>
 		/// <returns>Sizes of each dimension of stored data points</returns>
-		constexpr sizes<Dimensions> sizes() const noexcept { return _image_region.size; }
+		constexpr sizes<Dimensions> dimension_sizes() const noexcept { return _image_region.size; }
 		/// <summary></summary>
 		/// <returns>Image region of stored data points</returns>
 		constexpr data_region<Dimensions> region() const noexcept { return _image_region; }
@@ -78,16 +63,16 @@ namespace yagit::core::data
 
 		/// <summary></summary>
 		/// <returns>Total size of stored data points</returns>
-		constexpr size_t total_size() const noexcept { return total_size(sizes()); }
+		constexpr size_t total_size() const noexcept { return data::total_size(dimension_sizes()); }
 		/// <summary></summary>
 		/// <returns>Total allocated memory holding stored data points</returns>
-		constexpr size_t real_total_size() const noexcept { _real_total_size }
+		constexpr size_t real_total_size() const noexcept { return _real_total_size; }
 
 		/// <summary></summary>
 		/// <typeparam name="ElementMultiple">Count of elements to which alignment of the pointer to the stored data points should be checked</typeparam>
 		/// <returns>Checks if stored data points are aligned to sizeof(ElementType)*ElementMultiple</returns>
 		template<size_t ElementMultiple, typename = std::enable_if_t<detail::is_power_of_two_v<ElementMultiple>>>
-		constexpr bool is_aligned_to() const noexcept { detail::is_aligned_to<ElementMultiple>(data()); }
+		constexpr bool is_aligned_to() const noexcept { return core::is_aligned_to<ElementMultiple>(data()); }
 	public:
 		/// <summary></summary>
 		/// <returns>Const pointer to first stored data element</returns>

--- a/gi_core/include/data/image/iwritable_image.hpp
+++ b/gi_core/include/data/image/iwritable_image.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <common.hpp>
+#include <data/image/iwritable_image_region.hpp>
+#include <data/image/iimage.hpp>
+
+namespace yagit::core::data
+{
+	/// <summary>
+	/// Interface extending iimage functionality.
+	/// Should allow user to save data.
+	/// </summary>
+	/// <typeparam name="ElementType">Data point element type</typeparam>
+	/// <typeparam name="Dimensions">Dimensionality of image data point storage</typeparam>
+	template<typename ElementType, size_t Dimensions>
+	class iwritable_image
+		: public iwritable_image_region<ElementType, Dimensions>
+		, public iimage<ElementType, Dimensions>
+	{
+	public:
+		virtual ~iwritable_image() override = default;
+	};
+}

--- a/gi_core/include/data/image/iwritable_image_region.hpp
+++ b/gi_core/include/data/image/iwritable_image_region.hpp
@@ -1,0 +1,66 @@
+#pragma once
+
+#include <common.hpp>
+#include <data/image/iimage_region.hpp>
+
+namespace yagit::core::data
+{
+	/// <summary>
+	/// Interface extending iimage_region functionality.
+	/// Should allow user to save data.
+	/// </summary>
+	/// <typeparam name="ElementType">Data point element type</typeparam>
+	/// <typeparam name="Dimensions">Dimensionality of image data point storage</typeparam>
+	template<typename ElementType, size_t Dimensions>
+	class iwritable_image_region
+		: public virtual iimage_region<ElementType, Dimensions>
+	{
+	public:
+		virtual ~iwritable_image_region() = default;
+	public:
+		/// <summary>
+		/// <para>Implementable method responsible for data points saving</para>
+		/// </summary>
+		/// <param name="data">: Image data points to be saved.</param>
+		/// <returns>Error code informing about error that occured during execution unless success</returns>
+		virtual error_code save(const image_data<ElementType, Dimensions>& data) = 0;
+
+		/// <summary>
+		/// <para>Obtains an iimage_region corresponding to provided subregion.</para>
+		/// <para>Provided subregion should be interpreted locally i.e subregion is a subregion of region()
+		/// not whole image subregion</para>
+		/// <para>Can return null in four cases:</para>
+		/// <para> - provided region is bigger (in size) than region() </para>
+		/// <para> - provided region's offset is outside region() </para>
+		/// <para> - provided region is invalid i.e one of subregion sizes is 0</para>
+		/// <para> - implementation doesn't allow for taking subregions of this iimage_region</para>
+		/// </summary>
+		/// <param name="region">Subregion relative to region()</param>
+		/// <param name="ec">Error code</param>
+		/// <returns>iimage_region containing subregion defined by region</returns>
+		unique_ptr<iwritable_image_region<ElementType, Dimensions>> subregion(const data_region<Dimensions>& region, error_code& ec) const
+		{
+			return unique_ptr<iwritable_image_region<ElementType, Dimensions>>(create_subregion(region, ec));
+		}
+		unique_ptr<iwritable_image_region<ElementType, Dimensions>> subregion(const data_region<Dimensions>& region) const
+		{
+			error_code ec;
+			return subregion(region, ec);
+		}
+	protected:
+		/// <summary>
+		/// <para>Obtains an iimage_region corresponding to provided subregion.</para>
+		/// <para>Provided subregion should be interpreted locally i.e subregion is a subregion of region()
+		/// not whole image subregion</para>
+		/// <para>Can return null in four cases:</para>
+		/// <para> - provided region is bigger (in size) than region() </para>
+		/// <para> - provided region's offset is outside region() </para>
+		/// <para> - provided region is invalid i.e one of subregion sizes is 0</para>
+		/// <para> - implementation doesn't allow for taking subregions of this iimage_region</para>
+		/// </summary>
+		/// <param name="region">Subregion relative to region()</param>
+		/// <param name="ec">Error code</param>
+		/// <returns>transfers ownership of iimage_region containing subregion defined by region</returns>
+		virtual iwritable_image_region<ElementType, Dimensions>* create_subregion(const data_region<Dimensions>& region, error_code& ec) const = 0;
+	};
+}

--- a/gi_core/include/data/image/rtdose/image_coordinates.hpp
+++ b/gi_core/include/data/image/rtdose/image_coordinates.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <common.hpp>
-#include <data/image_data.hpp>
+#include <data/image/image_data.hpp>
 
 namespace yagit::core::data
 {

--- a/gi_core/include/data/image/rtdose/irtdose_image.hpp
+++ b/gi_core/include/data/image/rtdose/irtdose_image.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <common.hpp>
+#include <data/image/rtdose/irtdose_image_region.hpp>
+#include <data/image/iimage.hpp>
+
+namespace yagit::core::data
+{
+	// <summary>
+	/// Interface extending iimage functionality.
+	/// Represents RTDOSE dicom image.
+	/// </summary>
+	/// <typeparam name="ElementType">Data point element type</typeparam>
+	/// <typeparam name="Dimensions">Dimensionality of image data point storage</typeparam>
+	template<typename ElementType, size_t Dimensions>
+	class irtdose_image
+		: public virtual irtdose_image_region<ElementType, Dimensions>
+		, public iimage<ElementType, Dimensions>
+	{
+	public:
+		virtual ~irtdose_image() override = default;
+	};
+}

--- a/gi_core/include/data/image/rtdose/irtdose_image_region.hpp
+++ b/gi_core/include/data/image/rtdose/irtdose_image_region.hpp
@@ -1,0 +1,124 @@
+#pragma once
+
+#include <common.hpp>
+#include <data/image/iimage_region.hpp>
+#include <data/image/rtdose/image_coordinates.hpp>
+
+namespace yagit::core::data
+{
+	// <summary>
+	/// Interface extending iimage_region functionality.
+	/// Represents region of RTDOSE dicom image.
+	/// </summary>
+	/// <typeparam name="ElementType">Data point element type</typeparam>
+	/// <typeparam name="Dimensions">Dimensionality of image data point storage</typeparam>
+	template<typename ElementType, size_t Dimensions>
+	class irtdose_image_region
+		: public virtual iimage_region<ElementType, Dimensions>
+	{
+	public:
+		virtual ~irtdose_image_region() = default;
+	public:
+		/// <summary></summary>
+		/// <returns>Preferred implementation format to load the data point coordinates</returns>
+		template<size_t Dimension>
+		data_format<Dimensions> preferred_coordinates_format() const
+		{
+			return preferred_coordinates_format(Dimension);
+		}
+
+		/// <summary>
+		/// <para>Obtains an iimage_region corresponding to provided subregion.</para>
+		/// <para>Provided subregion should be interpreted locally i.e subregion is a subregion of region()
+		/// not whole image subregion</para>
+		/// <para>Can return null in four cases:</para>
+		/// <para> - provided region is bigger (in size) than region() </para>
+		/// <para> - provided region's offset is outside region() </para>
+		/// <para> - provided region is invalid i.e one of subregion sizes is 0</para>
+		/// <para> - implementation doesn't allow for taking subregions of this iimage_region</para>
+		/// </summary>
+		/// <param name="region">Subregion relative to region()</param>
+		/// <param name="ec">Error code</param>
+		/// <returns>iimage_region containing subregion defined by region</returns>
+		unique_ptr<irtdose_image_region<ElementType, Dimensions>> subregion(const data_region<Dimensions>& region, error_code& ec) const
+		{
+			return unique_ptr<irtdose_image_region<ElementType, Dimensions>>(create_subregion(region, ec));
+		}
+		unique_ptr<irtdose_image_region<ElementType, Dimensions>> subregion(const data_region<Dimensions>& region) const
+		{
+			error_code ec;
+			return subregion(region, ec);
+		}
+
+		// !! assumption about image coordinates type may be wrong as some image can have coordinates of type different
+		// to the data point type, this simplification that coordinate_type == data_point_type is strictly made to 
+		// unify all possible coordinate_types (to floating point type - ElementType) and simplify calculations that are using
+		// those coordinates as additional input along data points !!
+
+		/// <summary>
+		/// <para>Loads iimage_region image data point coordinates into memory buffer (image_coordinates)</para>
+		/// <para>iimage_region data point coordinats should be in the same order as corresponding data points</para>
+		/// <para>obtained by <see cref="iimage_region::load"/> provided they were obtained with the same data_format</para>
+		/// <para>TODO: describe and implement reasonable exception-less error handling</para>
+		/// </summary>
+		/// <typeparam name="Allocator">Allocator type to use for data storage allocation</typeparam>
+		/// <param name="format">: Data format in which data point coordinates should be loaded</param>
+		/// <param name="allocator">: Allocator to use for data storage allocation</param>
+		/// <param name="ec">Error code</param>
+		/// <returns>Loaded image data point coordinates into memory buffer (image_data)</returns>
+		template<size_t Dimension, typename Allocator = std::allocator<ElementType>, typename = std::enable_if_t<(Dimension < Dimensions)>>
+		optional<image_coordinates<ElementType, Dimensions>> load_coordinates(const data_format<Dimensions>& format, Allocator allocator, error_code& ec) const
+		{
+			size_t required_size = 0;
+
+			if (ec = load_coordinates(nullptr, Dimension, format, required_size))
+				return nullopt;
+
+			auto storage = this->allocate_at_least_for_image_data(std::move(allocator), required_size);
+
+			if (ec = load_coordinates(storage.get(), Dimension, format, required_size))
+				return nullopt;
+
+			return image_coordinates(std::move(storage), this->region(), format, required_size);
+		}
+		template<size_t Dimension, typename Allocator = std::allocator<ElementType>, typename = std::enable_if_t<(Dimension < Dimensions)>>
+		optional<image_coordinates<ElementType, Dimensions>> load_coordinates(const data_format<Dimensions>& format, Allocator allocator) const
+		{
+			error_code ec;
+			return load_coordinates(format, allocator, ec);
+		}
+	protected:
+		/// <summary></summary>
+		/// <returns>Preferred implementation format to load the data point coordinates</returns>
+		virtual data_format<Dimensions> preferred_coordinates_format(size_t dimension) const = 0;
+
+		/// <summary>
+		/// <para>Implementable method responsible for data point coordinates loading</para>
+		/// </summary>
+		/// <param name="data_storage">: Pointer to contiguous memory block to which data point coordinates should be loaded.</param>
+		/// <param name="format">: Format in which data point coordinates should be loaded. If data_storage is nullptr, this is argument is ignored.</param>
+		/// <param name="required_size">
+		/// : returns required size for data point coordinates loading imposed by implementation must 
+		/// be greater of equal to regular C array of type ElementType of size required to fit all data points in region().
+		/// If data_storage is nullptr, this argument returns implementation based required data points storage size.
+		/// Else is treated as an input informing about size of allocated storage, handling as input is implementation defined.
+		/// </param>
+		/// <returns>Error code informing about error that occured during execution unless success</returns>
+		virtual error_code load_coordinates(ElementType* data_storage, size_t dimension, const data_format<Dimensions>& format, size_t& required_size) const = 0;
+
+		/// <summary>
+		/// <para>Obtains an iimage_region corresponding to provided subregion.</para>
+		/// <para>Provided subregion should be interpreted locally i.e subregion is a subregion of region()
+		/// not whole image subregion</para>
+		/// <para>Can return null in four cases:</para>
+		/// <para> - provided region is bigger (in size) than region() </para>
+		/// <para> - provided region's offset is outside region() </para>
+		/// <para> - provided region is invalid i.e one of subregion sizes is 0</para>
+		/// <para> - implementation doesn't allow for taking subregions of this iimage_region</para>
+		/// </summary>
+		/// <param name="region">Subregion relative to region()</param>
+		/// <param name="ec">Error code</param>
+		/// <returns>transfers ownership of iimage_region containing subregion defined by region</returns>
+		virtual irtdose_image_region<ElementType, Dimensions>* create_subregion(const data_region<Dimensions>& region, error_code& ec) const = 0;
+	};
+}

--- a/gi_core/include/definitions.hpp
+++ b/gi_core/include/definitions.hpp
@@ -1,15 +1,17 @@
 #pragma once
 
 #include <cstddef>
+#include <cstdint>
 
 namespace yagit::core
 {
 	using size_t = std::size_t;
+	using ptrdiff_t = std::ptrdiff_t;
 
 	namespace data
 	{
 		template<size_t Dimensions>
-		struct offset;
+		struct offsets;
 		
 		template<size_t Dimensions>
 		struct sizes;

--- a/gi_core/include/math/basic/gamma_index_range.hpp
+++ b/gi_core/include/math/basic/gamma_index_range.hpp
@@ -1,0 +1,144 @@
+#pragma once
+
+#include <math/basic/gamma_index_range_impl.hpp>
+
+namespace yagit::core::math
+{
+	template<typename Type, size_t Dimensions>
+	struct sequenced_gamma_index_implementer {};
+
+	template<typename Type>
+	struct sequenced_gamma_index_implementer<Type, 1>
+	{
+		constexpr static error_code initialize_pass(view<Type> output, view<Type> output_end)
+		{
+			return basic::gamma_index_initialize_pass(output, output_end);
+		}
+		constexpr static error_code minimize_pass(
+			view<Type> output, view<Type> output_end,
+			const_view<Type> reference_doses,
+			std::array<const_view<Type>, 1> reference_coordinates,
+			const_view<Type> target_doses, const_view<Type> target_doses_end,
+			std::array<const_view<Type>, 1> target_coordinates,
+			const local_gamma_index_params<Type>& params)
+		{
+			return basic::gamma_index_minimize_pass(
+				output, output_end,
+				reference_doses,
+				reference_coordinates,
+				target_doses, target_doses_end,
+				target_coordinates,
+				params);
+		}
+		constexpr static error_code minimize_pass(
+			view<Type> output, view<Type> output_end,
+			const_view<Type> reference_doses,
+			std::array<const_view<Type>, 1> reference_coordinates,
+			const_view<Type> target_doses, const_view<Type> target_doses_end,
+			std::array<const_view<Type>, 1> target_coordinates,
+			const global_gamma_index_params<Type>& params)
+		{
+			return basic::gamma_index_minimize_pass(
+				output, output_end,
+				reference_doses,
+				reference_coordinates,
+				target_doses, target_doses_end,
+				target_coordinates,
+				params);
+		}
+		constexpr static error_code finalize_pass(view<Type> output, view<Type> output_end)
+		{
+			return basic::gamma_index_finalize_pass(output, output_end);
+		}
+	};
+
+	template<typename Type>
+	struct sequenced_gamma_index_implementer<Type, 2>
+	{
+		constexpr static error_code initialize_pass(view<Type> output, view<Type> output_end)
+		{
+			return basic::gamma_index_initialize_pass(output, output_end);
+		}
+		constexpr static error_code minimize_pass(
+			view<Type> output, view<Type> output_end,
+			const_view<Type> reference_doses,
+			std::array<const_view<Type>, 2> reference_coordinates,
+			const_view<Type> target_doses, const_view<Type> target_doses_end,
+			std::array<const_view<Type>, 2> target_coordinates,
+			const local_gamma_index_params<Type>& params)
+		{
+			return basic::gamma_index_minimize_pass(
+				output, output_end,
+				reference_doses,
+				reference_coordinates,
+				target_doses, target_doses_end,
+				target_coordinates,
+				params);
+		}
+		constexpr static error_code minimize_pass(
+			view<Type> output, view<Type> output_end,
+			const_view<Type> reference_doses,
+			std::array<const_view<Type>, 2> reference_coordinates,
+			const_view<Type> target_doses, const_view<Type> target_doses_end,
+			std::array<const_view<Type>, 2> target_coordinates,
+			const global_gamma_index_params<Type>& params)
+		{
+			return basic::gamma_index_minimize_pass(
+				output, output_end,
+				reference_doses,
+				reference_coordinates,
+				target_doses, target_doses_end,
+				target_coordinates,
+				params);
+		}
+		constexpr static error_code finalize_pass(view<Type> output, view<Type> output_end)
+		{
+			return basic::gamma_index_finalize_pass(output, output_end);
+		}
+	};
+
+	template<typename Type>
+	struct sequenced_gamma_index_implementer<Type, 3>
+	{
+		constexpr static error_code initialize_pass(view<Type> output, view<Type> output_end)
+		{
+			return basic::gamma_index_initialize_pass(output, output_end);
+		}
+		constexpr static error_code minimize_pass(
+			view<Type> output, view<Type> output_end,
+			const_view<Type> reference_doses,
+			std::array<const_view<Type>, 3> reference_coordinates,
+			const_view<Type> target_doses, const_view<Type> target_doses_end,
+			std::array<const_view<Type>, 3> target_coordinates,
+			const local_gamma_index_params<Type>& params)
+		{
+			return basic::gamma_index_minimize_pass(
+				output, output_end,
+				reference_doses,
+				reference_coordinates,
+				target_doses, target_doses_end,
+				target_coordinates,
+				params);
+		}
+		constexpr static error_code minimize_pass(
+			view<Type> output, view<Type> output_end,
+			const_view<Type> reference_doses,
+			std::array<const_view<Type>, 3> reference_coordinates,
+			const_view<Type> target_doses, const_view<Type> target_doses_end,
+			std::array<const_view<Type>, 3> target_coordinates,
+			const global_gamma_index_params<Type>& params)
+		{
+			return basic::gamma_index_minimize_pass(
+				output, output_end,
+				reference_doses,
+				reference_coordinates,
+				target_doses, target_doses_end,
+				target_coordinates,
+				params);
+		}
+		constexpr static error_code finalize_pass(view<Type> output, view<Type> output_end)
+		{
+			return basic::gamma_index_finalize_pass(output, output_end);
+		}
+	};
+}

--- a/gi_core/include/math/basic/gamma_index_range_impl.hpp
+++ b/gi_core/include/math/basic/gamma_index_range_impl.hpp
@@ -1,0 +1,91 @@
+#pragma once
+
+#include <math/basic/gamma_index_single.hpp>
+
+namespace yagit::core::math::basic
+{
+	namespace detail
+	{
+		template<typename Type, size_t Dimensions, typename ParamsType, size_t... I>
+		constexpr error_code gamma_index_minimize_pass(
+			view<Type> gamma_index_output, view<Type> gamma_index_output_end,
+			const_view<Type> reference_doses,
+			array<const_view<Type>, Dimensions> reference_coordinates,
+			const_view<Type> target_doses, const_view<Type> target_doses_end,
+			array<const_view<Type>, Dimensions> target_coordinates,
+			const ParamsType& params,
+			index_sequence<I...>)
+		{
+			for (;
+				gamma_index_output != gamma_index_output_end;
+				++gamma_index_output, ++reference_doses, ((++reference_coordinates[I]),...))
+			{
+				if (std::isnan(*gamma_index_output) || *gamma_index_output < static_cast<Type>(1))
+					continue;
+
+				if (std::isnan(*reference_doses))
+				{
+					*gamma_index_output = *reference_doses;
+					continue;
+				}
+
+				Type min_gi = numeric_limits<Type>::max();
+				const_view<Type> t_doses = target_doses;
+				array<const_view<Type>, Dimensions> t_coordinates = target_coordinates;
+				for (;
+					t_doses != target_doses_end;
+					++t_doses, ((++t_coordinates[I]),...))
+				{
+					if (std::isnan(*t_doses))
+						continue;
+
+					min_gi = std::min(
+						min_gi,
+						gamma_index(*reference_doses, *t_doses, (*reference_coordinates[I])..., (*t_coordinates[I])..., params)
+					);
+
+					if (min_gi < static_cast<Type>(1))
+						break;
+				}
+
+				*gamma_index_output = std::min(*gamma_index_output, min_gi);
+			}
+
+			return {};
+		}
+	}
+
+	template<typename Type>
+	constexpr error_code gamma_index_initialize_pass(view<Type> gamma_index_output, view<Type> gamma_index_output_end)
+	{
+		std::fill(gamma_index_output, gamma_index_output_end, std::numeric_limits<Type>::max());
+		return {};
+	}
+
+	template<typename Type, size_t Dimensions, typename ParamsType>
+	constexpr error_code gamma_index_minimize_pass(
+		view<Type> gamma_index_output, view<Type> gamma_index_output_end,
+		const_view<Type> reference_doses,
+		array<const_view<Type>, Dimensions> reference_coordinates,
+		const_view<Type> target_doses, const_view<Type> target_doses_end,
+		array<const_view<Type>, Dimensions> target_coordinates,
+		const ParamsType& params)
+	{
+		return detail::gamma_index_minimize_pass(
+			gamma_index_output, gamma_index_output_end,
+			reference_doses,
+			reference_coordinates,
+			target_doses, target_doses_end,
+			target_coordinates,
+			params,
+			std::make_index_sequence<Dimensions>()
+		);
+	}
+
+	template<typename Type>
+	constexpr error_code gamma_index_finalize_pass(view<Type> gamma_index_output, view<Type> gamma_index_output_end)
+	{
+		std::transform(gamma_index_output, gamma_index_output_end, gamma_index_output, [](auto v) {return std::sqrt(v); });
+		return {};
+	}
+}

--- a/gi_core/include/math/basic/gamma_index_single.hpp
+++ b/gi_core/include/math/basic/gamma_index_single.hpp
@@ -1,0 +1,156 @@
+#pragma once
+
+#include <math/common.hpp>
+
+namespace yagit::core::math::basic
+{
+	template<typename Type>
+	inline constexpr Type dose_difference(
+		Type reference_dose, Type target_dose,
+		const local_gamma_index_params<Type>& params)
+	{
+		auto intermediate = (reference_dose - target_dose) / (reference_dose * params.percentage);
+		return intermediate * intermediate;
+	}
+
+	template<typename Type>
+	inline constexpr Type dose_difference(
+		Type reference_dose, Type target_dose,
+		const global_gamma_index_params<Type>& params)
+	{
+		auto intermediate = (reference_dose - target_dose);
+		return (intermediate * intermediate) / params.dose_difference_squared;
+	}
+
+	template<typename Type>
+	inline constexpr Type distance_to_agreement(
+		Type reference_x,
+		Type target_x,
+		const local_gamma_index_params<Type>& params)
+	{
+		auto intermediate_x = (target_x - reference_x);
+		return (intermediate_x * intermediate_x) / params.distance_to_agreement_squared;
+	}
+
+	template<typename Type>
+	inline constexpr Type distance_to_agreement(
+		Type reference_x, Type reference_y,
+		Type target_x, Type target_y,
+		const local_gamma_index_params<Type>& params)
+	{
+		auto intermediate_x = (target_x - reference_x);
+		auto intermediate_y = (target_y - reference_y);
+		return (intermediate_x * intermediate_x + intermediate_y * intermediate_y) / params.distance_to_agreement_squared;
+	}
+
+	template<typename Type>
+	inline constexpr Type distance_to_agreement(
+		Type reference_x, Type reference_y, Type reference_z,
+		Type target_x, Type target_y, Type target_z,
+		const local_gamma_index_params<Type>& params)
+	{
+		auto intermediate_x = (target_x - reference_x);
+		auto intermediate_y = (target_y - reference_y);
+		auto intermediate_z = (target_z - reference_z);
+		return (intermediate_x * intermediate_x + intermediate_y * intermediate_y + intermediate_z * intermediate_z) / params.distance_to_agreement_squared;
+	}
+
+	template<typename Type>
+	inline constexpr Type distance_to_agreement(
+		Type reference_x,
+		Type target_x,
+		const global_gamma_index_params<Type>& params)
+	{
+		auto intermediate_x = (target_x - reference_x);
+		return (intermediate_x * intermediate_x) / params.distance_to_agreement_squared;
+	}
+
+	template<typename Type>
+	inline constexpr Type distance_to_agreement(
+		Type reference_x, Type reference_y,
+		Type target_x, Type target_y,
+		const global_gamma_index_params<Type>& params)
+	{
+		auto intermediate_x = (target_x - reference_x);
+		auto intermediate_y = (target_y - reference_y);
+		return (intermediate_x * intermediate_x + intermediate_y * intermediate_y) / params.distance_to_agreement_squared;
+	}
+
+	template<typename Type>
+	inline constexpr Type distance_to_agreement(
+		Type reference_x, Type reference_y, Type reference_z,
+		Type target_x, Type target_y, Type target_z,
+		const global_gamma_index_params<Type>& params)
+	{
+		auto intermediate_x = (target_x - reference_x);
+		auto intermediate_y = (target_y - reference_y);
+		auto intermediate_z = (target_z - reference_z);
+		return (intermediate_x * intermediate_x + intermediate_y * intermediate_y + intermediate_z * intermediate_z) / params.distance_to_agreement_squared;
+	}
+
+	template<typename Type>
+	inline constexpr Type gamma_index(
+		Type reference_dose,
+		Type target_dose,
+		Type reference_x,
+		Type target_x,
+		const local_gamma_index_params<Type>& params)
+	{
+		return dose_difference(reference_dose, target_dose, params) + distance_to_agreement(reference_x, target_x, params);
+	}
+
+	template<typename Type>
+	inline constexpr Type gamma_index(
+		Type reference_dose,
+		Type target_dose,
+		Type reference_x, Type reference_y,
+		Type target_x, Type target_y,
+		const local_gamma_index_params<Type>& params)
+	{
+		return dose_difference(reference_dose, target_dose, params) + distance_to_agreement(reference_x, reference_y, target_x, target_y, params);
+	}
+
+	template<typename Type>
+	inline constexpr Type gamma_index(
+		Type reference_dose, 
+		Type target_dose,
+		Type reference_x, Type reference_y, Type reference_z,
+		Type target_x, Type target_y, Type target_z,
+		const local_gamma_index_params<Type>& params)
+	{
+		return dose_difference(reference_dose, target_dose, params) + distance_to_agreement(reference_x, reference_y, reference_z, target_x, target_y, target_z, params);
+	}
+
+	template<typename Type>
+	inline constexpr Type gamma_index(
+		Type reference_dose,
+		Type target_dose,
+		Type reference_x,
+		Type target_x,
+		const global_gamma_index_params<Type>& params)
+	{
+		return dose_difference(reference_dose, target_dose, params) + distance_to_agreement(reference_x, target_x, params);
+	}
+
+	template<typename Type>
+	inline constexpr Type gamma_index(
+		Type reference_dose,
+		Type target_dose,
+		Type reference_x, Type reference_y,
+		Type target_x, Type target_y,
+		const global_gamma_index_params<Type>& params)
+	{
+		return dose_difference(reference_dose, target_dose, params) + distance_to_agreement(reference_x, reference_y, target_x, target_y, params);
+	}
+
+	template<typename Type>
+	inline constexpr Type gamma_index(
+		Type reference_dose,
+		Type target_dose,
+		Type reference_x, Type reference_y, Type reference_z,
+		Type target_x, Type target_y, Type target_z,
+		const global_gamma_index_params<Type>& params)
+	{
+		return dose_difference(reference_dose, target_dose, params) + distance_to_agreement(reference_x, reference_y, reference_z, target_x, target_y, target_z, params);
+	}
+}

--- a/gi_core/include/math/basic/openmp/gamma_index_range.hpp
+++ b/gi_core/include/math/basic/openmp/gamma_index_range.hpp
@@ -1,0 +1,144 @@
+#pragma once
+
+#include <math/basic/openmp/gamma_index_range_impl.hpp>
+
+namespace yagit::core::math
+{
+	template<typename Type, size_t Dimensions>
+	struct parallel_gamma_index_implementer {};
+
+	template<typename Type>
+	struct parallel_gamma_index_implementer<Type, 1>
+	{
+		constexpr static error_code initialize_pass(view<Type> output, view<Type> output_end)
+		{
+			return basic::openmp::gamma_index_initialize_pass(output, output_end);
+		}
+		constexpr static error_code minimize_pass(
+			view<Type> output, view<Type> output_end,
+			const_view<Type> reference_doses,
+			std::array<const_view<Type>, 1> reference_coordinates,
+			const_view<Type> target_doses, const_view<Type> target_doses_end,
+			std::array<const_view<Type>, 1> target_coordinates,
+			const local_gamma_index_params<Type>& params)
+		{
+			return basic::openmp::gamma_index_minimize_pass(
+				output, output_end,
+				reference_doses,
+				reference_coordinates,
+				target_doses, target_doses_end,
+				target_coordinates,
+				params);
+		}
+		constexpr static error_code minimize_pass(
+			view<Type> output, view<Type> output_end,
+			const_view<Type> reference_doses,
+			std::array<const_view<Type>, 1> reference_coordinates,
+			const_view<Type> target_doses, const_view<Type> target_doses_end,
+			std::array<const_view<Type>, 1> target_coordinates,
+			const global_gamma_index_params<Type>& params)
+		{
+			return basic::openmp::gamma_index_minimize_pass(
+				output, output_end,
+				reference_doses,
+				reference_coordinates,
+				target_doses, target_doses_end,
+				target_coordinates,
+				params);
+		}
+		constexpr static error_code finalize_pass(view<Type> output, view<Type> output_end)
+		{
+			return basic::openmp::gamma_index_finalize_pass(output, output_end);
+		}
+	};
+
+	template<typename Type>
+	struct parallel_gamma_index_implementer<Type, 2>
+	{
+		constexpr static error_code initialize_pass(view<Type> output, view<Type> output_end)
+		{
+			return basic::openmp::gamma_index_initialize_pass(output, output_end);
+		}
+		constexpr static error_code minimize_pass(
+			view<Type> output, view<Type> output_end,
+			const_view<Type> reference_doses,
+			std::array<const_view<Type>, 2> reference_coordinates,
+			const_view<Type> target_doses, const_view<Type> target_doses_end,
+			std::array<const_view<Type>, 2> target_coordinates,
+			const local_gamma_index_params<Type>& params)
+		{
+			return basic::openmp::gamma_index_minimize_pass(
+				output, output_end,
+				reference_doses,
+				reference_coordinates,
+				target_doses, target_doses_end,
+				target_coordinates,
+				params);
+		}
+		constexpr static error_code minimize_pass(
+			view<Type> output, view<Type> output_end,
+			const_view<Type> reference_doses,
+			std::array<const_view<Type>, 2> reference_coordinates,
+			const_view<Type> target_doses, const_view<Type> target_doses_end,
+			std::array<const_view<Type>, 2> target_coordinates,
+			const global_gamma_index_params<Type>& params)
+		{
+			return basic::openmp::gamma_index_minimize_pass(
+				output, output_end,
+				reference_doses,
+				reference_coordinates,
+				target_doses, target_doses_end,
+				target_coordinates,
+				params);
+		}
+		constexpr static error_code finalize_pass(view<Type> output, view<Type> output_end)
+		{
+			return basic::openmp::gamma_index_finalize_pass(output, output_end);
+		}
+	};
+
+	template<typename Type>
+	struct parallel_gamma_index_implementer<Type, 3>
+	{
+		constexpr static error_code initialize_pass(view<Type> output, view<Type> output_end)
+		{
+			return basic::openmp::gamma_index_initialize_pass(output, output_end);
+		}
+		constexpr static error_code minimize_pass(
+			view<Type> output, view<Type> output_end,
+			const_view<Type> reference_doses,
+			std::array<const_view<Type>, 3> reference_coordinates,
+			const_view<Type> target_doses, const_view<Type> target_doses_end,
+			std::array<const_view<Type>, 3> target_coordinates,
+			const local_gamma_index_params<Type>& params)
+		{
+			return basic::openmp::gamma_index_minimize_pass(
+				output, output_end,
+				reference_doses,
+				reference_coordinates,
+				target_doses, target_doses_end,
+				target_coordinates,
+				params);
+		}
+		constexpr static error_code minimize_pass(
+			view<Type> output, view<Type> output_end,
+			const_view<Type> reference_doses,
+			std::array<const_view<Type>, 3> reference_coordinates,
+			const_view<Type> target_doses, const_view<Type> target_doses_end,
+			std::array<const_view<Type>, 3> target_coordinates,
+			const global_gamma_index_params<Type>& params)
+		{
+			return basic::openmp::gamma_index_minimize_pass(
+				output, output_end,
+				reference_doses,
+				reference_coordinates,
+				target_doses, target_doses_end,
+				target_coordinates,
+				params);
+		}
+		constexpr static error_code finalize_pass(view<Type> output, view<Type> output_end)
+		{
+			return basic::openmp::gamma_index_finalize_pass(output, output_end);
+		}
+	};
+}

--- a/gi_core/include/math/basic/openmp/gamma_index_range_impl.hpp
+++ b/gi_core/include/math/basic/openmp/gamma_index_range_impl.hpp
@@ -1,0 +1,104 @@
+#pragma once
+
+
+#include <math/basic/gamma_index_single.hpp>
+#include <execution>
+#if !defined(YAGIT_OPENMP)
+#include <math/basic/gamma_index_range_impl.hpp>
+#endif
+
+namespace yagit::core::math::basic::openmp
+{
+	namespace detail
+	{
+#if defined(YAGIT_OPENMP)
+		template<typename Type, size_t Dimensions, typename ParamsType, size_t... I>
+		constexpr error_code gamma_index_minimize_pass(
+			view<Type> gamma_index_output, view<Type> gamma_index_output_end,
+			const_view<Type> reference_doses,
+			array<const_view<Type>, Dimensions> reference_coordinates,
+			const_view<Type> target_doses, const_view<Type> target_doses_end,
+			array<const_view<Type>, Dimensions> target_coordinates,
+			const ParamsType& params,
+			index_sequence<I...>)
+		{
+			size_t output_size = gamma_index_output_end - gamma_index_output;
+#pragma omp parallel for
+			for (long i = 0; i < output_size; i++)
+			{
+				auto gi_output = gamma_index_output + i;
+				auto ref_doses = reference_doses + i;
+				array<const_view<Type>, Dimensions> ref_coordinates = { (reference_coordinates[I] + i)... };
+
+				if (std::isnan(*gi_output) || *gi_output < static_cast<Type>(1))
+					continue;
+
+				if (std::isnan(*ref_doses))
+				{
+					*gi_output = *ref_doses;
+					continue;
+				}
+
+				Type min_gi = numeric_limits<Type>::max();
+				const_view<Type> t_doses = target_doses;
+				array<const_view<Type>, Dimensions> t_coordinates = target_coordinates;
+				for (;
+					t_doses != target_doses_end;
+					++t_doses, ((++t_coordinates[I]),...))
+				{
+					if (std::isnan(*t_doses))
+						continue;
+
+					min_gi = std::min(
+						min_gi,
+						gamma_index(*ref_doses, *t_doses, (*ref_coordinates[I])..., (*t_coordinates[I])..., params)
+					);
+
+					if (min_gi < static_cast<Type>(1))
+						break;
+				}
+
+				*gi_output = std::min(*gi_output, min_gi);
+			}
+
+			return {};
+		}
+#else
+		using basic::detail::gamma_index_minimize_pass;
+#endif
+	}
+
+	template<typename Type>
+	constexpr error_code gamma_index_initialize_pass(view<Type> gamma_index_output, view<Type> gamma_index_output_end)
+	{
+		std::fill(std::execution::par, gamma_index_output, gamma_index_output_end, std::numeric_limits<Type>::max());
+		return {};
+	}
+
+	template<typename Type, size_t Dimensions, typename ParamsType>
+	constexpr error_code gamma_index_minimize_pass(
+		view<Type> gamma_index_output, view<Type> gamma_index_output_end,
+		const_view<Type> reference_doses,
+		array<const_view<Type>, Dimensions> reference_coordinates,
+		const_view<Type> target_doses, const_view<Type> target_doses_end,
+		array<const_view<Type>, Dimensions> target_coordinates,
+		const ParamsType& params)
+	{
+		return detail::gamma_index_minimize_pass(
+			gamma_index_output, gamma_index_output_end,
+			reference_doses,
+			reference_coordinates,
+			target_doses, target_doses_end,
+			target_coordinates,
+			params,
+			std::make_index_sequence<Dimensions>()
+		);
+	}
+
+	template<typename Type>
+	constexpr error_code gamma_index_finalize_pass(view<Type> gamma_index_output, view<Type> gamma_index_output_end)
+	{
+		std::transform(std::execution::par, gamma_index_output, gamma_index_output_end, gamma_index_output, [](auto v) {return std::sqrt(v); });
+		return {};
+	}
+}

--- a/gi_core/include/math/common.hpp
+++ b/gi_core/include/math/common.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <common.hpp>
+#include <cmath>
+
+namespace yagit::core::math
+{
+	template<typename T>
+	struct local_gamma_index_params
+	{
+		using value_type = T;
+
+		value_type percentage;
+		value_type distance_to_agreement_squared;
+	};
+
+	template<typename T>
+	struct global_gamma_index_params
+	{
+		using value_type = T;
+
+		value_type dose_difference_squared;
+		value_type distance_to_agreement_squared;
+	};
+
+	template<typename T>
+	struct gamma_index_params
+	{
+		using value_type = T;
+		using variant_type = variant<local_gamma_index_params<value_type>, global_gamma_index_params<value_type>>;
+
+		variant_type params;
+	};
+}

--- a/gi_core/include/math/gamma_index.hpp
+++ b/gi_core/include/math/gamma_index.hpp
@@ -1,0 +1,1177 @@
+#pragma once
+
+#include <data/image/iwritable_image.hpp>
+#include <data/image/rtdose/irtdose_image.hpp>
+#include <data/image/image_data.hpp>
+#include <data/image/rtdose/image_coordinates.hpp>
+
+#include <math/basic/gamma_index_range.hpp>
+#include <math/basic/openmp/gamma_index_range.hpp>
+#include <math/vectorized/gamma_index_range.hpp>
+#include <math/vectorized/openmp/gamma_index_range.hpp>
+
+#include <execution>
+
+namespace yagit::core::math
+{
+	using yagit::core::data::data_region;
+
+	using yagit::core::data::iwritable_image;
+	using yagit::core::data::iwritable_image_region;
+
+	using yagit::core::data::irtdose_image;
+	using yagit::core::data::irtdose_image_region;
+
+	using yagit::core::data::image_data;
+	using yagit::core::data::image_coordinates;
+
+	namespace detail
+	{
+		template<size_t Dimensions>
+		bool gamma_index_should_split(const data_region<Dimensions>& region)
+		{
+			return false;
+		}
+
+		template<size_t Dimensions, typename Type>
+		inline error_code gamma_index_initialize_pass(std::execution::sequenced_policy, view<Type> gamma_index_output, view<Type> gamma_index_output_end)
+		{
+			return sequenced_gamma_index_implementer<Type, Dimensions>::initialize_pass(gamma_index_output, gamma_index_output_end);
+		}
+
+		template<size_t Dimensions, typename Type>
+		inline error_code gamma_index_initialize_pass(std::execution::unsequenced_policy, view<Type> gamma_index_output, view<Type> gamma_index_output_end)
+		{
+			return unsequenced_gamma_index_implementer<Type, Dimensions>::initialize_pass(gamma_index_output, gamma_index_output_end);
+		}
+
+		template<size_t Dimensions, typename Type>
+		inline error_code gamma_index_initialize_pass(std::execution::parallel_policy, view<Type> gamma_index_output, view<Type> gamma_index_output_end)
+		{
+			return parallel_gamma_index_implementer<Type, Dimensions>::initialize_pass(gamma_index_output, gamma_index_output_end);
+		}
+
+		template<size_t Dimensions, typename Type>
+		inline error_code gamma_index_initialize_pass(std::execution::parallel_unsequenced_policy, view<Type> gamma_index_output, view<Type> gamma_index_output_end)
+		{
+			return parallel_unsequenced_gamma_index_implementer<Type, Dimensions>::initialize_pass(gamma_index_output, gamma_index_output_end);
+		}
+
+		template<typename Type, size_t Dimensions>
+		inline error_code gamma_index_minimize_pass(
+			std::execution::sequenced_policy,
+			view<Type> output, view<Type> output_end,
+			const_view<Type> reference_doses,
+			array<const_view<Type>, Dimensions> reference_coordinates,
+			const_view<Type> target_doses, const_view<Type> target_doses_end,
+			array<const_view<Type>, Dimensions> target_coordinates,
+			const local_gamma_index_params<Type>& params)
+		{
+			return sequenced_gamma_index_implementer<Type, Dimensions>::minimize_pass(
+				output, output_end,
+				reference_doses,
+				reference_coordinates,
+				target_doses, target_doses_end,
+				target_coordinates,
+				params);
+		}
+
+		template<typename Type, size_t Dimensions>
+		inline error_code gamma_index_minimize_pass(
+			std::execution::sequenced_policy,
+			view<Type> output, view<Type> output_end,
+			const_view<Type> reference_doses,
+			array<const_view<Type>, Dimensions> reference_coordinates,
+			const_view<Type> target_doses, const_view<Type> target_doses_end,
+			array<const_view<Type>, Dimensions> target_coordinates,
+			const global_gamma_index_params<Type>& params)
+		{
+			return sequenced_gamma_index_implementer<Type, Dimensions>::minimize_pass(
+				output, output_end,
+				reference_doses,
+				reference_coordinates,
+				target_doses, target_doses_end,
+				target_coordinates,
+				params);
+		}
+
+		template<typename Type, size_t Dimensions>
+		inline error_code gamma_index_minimize_pass(
+			std::execution::unsequenced_policy,
+			view<Type> output, view<Type> output_end,
+			const_view<Type> reference_doses,
+			array<const_view<Type>, Dimensions> reference_coordinates,
+			const_view<Type> target_doses, const_view<Type> target_doses_end,
+			array<const_view<Type>, Dimensions> target_coordinates,
+			const local_gamma_index_params<Type>& params)
+		{
+			return unsequenced_gamma_index_implementer<Type, Dimensions>::minimize_pass(
+				output, output_end,
+				reference_doses,
+				reference_coordinates,
+				target_doses, target_doses_end,
+				target_coordinates,
+				params);
+		}
+
+		template<typename Type, size_t Dimensions>
+		inline error_code gamma_index_minimize_pass(
+			std::execution::unsequenced_policy,
+			view<Type> output, view<Type> output_end,
+			const_view<Type> reference_doses,
+			array<const_view<Type>, Dimensions> reference_coordinates,
+			const_view<Type> target_doses, const_view<Type> target_doses_end,
+			array<const_view<Type>, Dimensions> target_coordinates,
+			const global_gamma_index_params<Type>& params)
+		{
+			return unsequenced_gamma_index_implementer<Type, Dimensions>::minimize_pass(
+				output, output_end,
+				reference_doses,
+				reference_coordinates,
+				target_doses, target_doses_end,
+				target_coordinates,
+				params);
+		}
+
+		template<typename Type, size_t Dimensions>
+		inline error_code gamma_index_minimize_pass(
+			std::execution::parallel_policy,
+			view<Type> output, view<Type> output_end,
+			const_view<Type> reference_doses,
+			array<const_view<Type>, Dimensions> reference_coordinates,
+			const_view<Type> target_doses, const_view<Type> target_doses_end,
+			array<const_view<Type>, Dimensions> target_coordinates,
+			const local_gamma_index_params<Type>& params)
+		{
+			return parallel_gamma_index_implementer<Type, Dimensions>::minimize_pass(
+				output, output_end,
+				reference_doses,
+				reference_coordinates,
+				target_doses, target_doses_end,
+				target_coordinates,
+				params);
+		}
+
+		template<typename Type, size_t Dimensions>
+		inline error_code gamma_index_minimize_pass(
+			std::execution::parallel_policy,
+			view<Type> output, view<Type> output_end,
+			const_view<Type> reference_doses,
+			array<const_view<Type>, Dimensions> reference_coordinates,
+			const_view<Type> target_doses, const_view<Type> target_doses_end,
+			array<const_view<Type>, Dimensions> target_coordinates,
+			const global_gamma_index_params<Type>& params)
+		{
+			return parallel_gamma_index_implementer<Type, Dimensions>::minimize_pass(
+				output, output_end,
+				reference_doses,
+				reference_coordinates,
+				target_doses, target_doses_end,
+				target_coordinates,
+				params);
+		}
+
+		template<typename Type, size_t Dimensions>
+		inline error_code gamma_index_minimize_pass(
+			std::execution::parallel_unsequenced_policy,
+			view<Type> output, view<Type> output_end,
+			const_view<Type> reference_doses,
+			array<const_view<Type>, Dimensions> reference_coordinates,
+			const_view<Type> target_doses, const_view<Type> target_doses_end,
+			array<const_view<Type>, Dimensions> target_coordinates,
+			const local_gamma_index_params<Type>& params)
+		{
+			return parallel_unsequenced_gamma_index_implementer<Type, Dimensions>::minimize_pass(
+				output, output_end,
+				reference_doses,
+				reference_coordinates,
+				target_doses, target_doses_end,
+				target_coordinates,
+				params);
+		}
+
+		template<typename Type, size_t Dimensions>
+		inline error_code gamma_index_minimize_pass(
+			std::execution::parallel_unsequenced_policy,
+			view<Type> output, view<Type> output_end,
+			const_view<Type> reference_doses,
+			array<const_view<Type>, Dimensions> reference_coordinates,
+			const_view<Type> target_doses, const_view<Type> target_doses_end,
+			array<const_view<Type>, Dimensions> target_coordinates,
+			const global_gamma_index_params<Type>& params)
+		{
+			return parallel_unsequenced_gamma_index_implementer<Type, Dimensions>::minimize_pass(
+				output, output_end,
+				reference_doses,
+				reference_coordinates,
+				target_doses, target_doses_end,
+				target_coordinates,
+				params);
+		}
+
+		template<size_t Dimensions, typename Type>
+		inline error_code gamma_index_finalize_pass(std::execution::sequenced_policy, view<Type> gamma_index_output, view<Type> gamma_index_output_end)
+		{
+			return sequenced_gamma_index_implementer<Type, Dimensions>::finalize_pass(gamma_index_output, gamma_index_output_end);
+		}
+
+		template<size_t Dimensions, typename Type>
+		inline error_code gamma_index_finalize_pass(std::execution::unsequenced_policy, view<Type> gamma_index_output, view<Type> gamma_index_output_end)
+		{
+			return unsequenced_gamma_index_implementer<Type, Dimensions>::finalize_pass(gamma_index_output, gamma_index_output_end);
+		}
+
+		template<size_t Dimensions, typename Type>
+		inline error_code gamma_index_finalize_pass(std::execution::parallel_policy, view<Type> gamma_index_output, view<Type> gamma_index_output_end)
+		{
+			return parallel_gamma_index_implementer<Type, Dimensions>::finalize_pass(gamma_index_output, gamma_index_output_end);
+		}
+
+		template<size_t Dimensions, typename Type>
+		inline error_code gamma_index_finalize_pass(std::execution::parallel_unsequenced_policy, view<Type> gamma_index_output, view<Type> gamma_index_output_end)
+		{
+			return parallel_unsequenced_gamma_index_implementer<Type, Dimensions>::finalize_pass(gamma_index_output, gamma_index_output_end);
+		}
+
+		// -------- image_data, image_coordinates --------
+
+		template<typename Type, typename ExecutionPolicy>
+		error_code gamma_index(
+			ExecutionPolicy policy,
+			image_data<Type, 1>& gamma_index_output,
+			const image_data<Type, 1>& reference_doses,
+			const image_coordinates<Type, 1>& reference_x_coordinates,
+			const image_data<Type, 1>& target_doses,
+			const image_coordinates<Type, 1>& target_x_coordinate,
+			const local_gamma_index_params<Type>& params
+		)
+		{
+			return gamma_index_minimize_pass(
+				policy,
+				gamma_index_output.data(), gamma_index_output.data() + gamma_index_output.total_size(),
+				reference_doses.data(),
+				array<const_view<Type>, 1>{ reference_x_coordinates.data() },
+				target_doses.data(), target_doses.data() + target_doses.total_size(),
+				array<const_view<Type>, 1>{ target_x_coordinate.data() },
+				params);
+		}
+
+		template<typename Type, typename ExecutionPolicy>
+		error_code gamma_index(
+			ExecutionPolicy policy,
+			image_data<Type, 2>& gamma_index_output,
+			const image_data<Type, 2>& reference_doses,
+			const image_coordinates<Type, 2>& reference_x_coordinates, const image_coordinates<Type, 2>& reference_y_coordinates,
+			const image_data<Type, 2>& target_doses,
+			const image_coordinates<Type, 2>& target_x_coordinate, const image_coordinates<Type, 2>& target_y_coordinate,
+			const local_gamma_index_params<Type>& params
+		)
+		{
+			return gamma_index_minimize_pass(
+				policy,
+				gamma_index_output.data(), gamma_index_output.data() + gamma_index_output.total_size(),
+				reference_doses.data(),
+				array<const_view<Type>, 2>{ reference_x_coordinates.data(), reference_y_coordinates.data() },
+				target_doses.data(), target_doses.data() + target_doses.total_size(),
+				array<const_view<Type>, 2>{ target_x_coordinate.data(), target_y_coordinate.data() },
+				params);
+		}
+
+		template<typename Type, typename ExecutionPolicy>
+		error_code gamma_index(
+			ExecutionPolicy policy,
+			image_data<Type, 3>& gamma_index_output,
+			const image_data<Type, 3>& reference_doses,
+			const image_coordinates<Type, 3>& reference_x_coordinates, const image_coordinates<Type, 3>& reference_y_coordinates, const image_coordinates<Type, 3>& reference_z_coordinates,
+			const image_data<Type, 3>& target_doses,
+			const image_coordinates<Type, 3>& target_x_coordinate, const image_coordinates<Type, 3>& target_y_coordinate, const image_coordinates<Type, 3>& target_z_coordinate,
+			const local_gamma_index_params<Type>& params
+		)
+		{
+			return gamma_index_minimize_pass(
+				policy,
+				gamma_index_output.data(), gamma_index_output.data() + gamma_index_output.total_size(),
+				reference_doses.data(),
+				array<const_view<Type>, 3>{ reference_x_coordinates.data(), reference_y_coordinates.data(), reference_z_coordinates.data() },
+				target_doses.data(), target_doses.data() + target_doses.total_size(),
+				array<const_view<Type>, 3>{ target_x_coordinate.data(), target_y_coordinate.data(), target_z_coordinate.data() },
+				params);
+		}
+
+		template<typename Type, typename ExecutionPolicy>
+		error_code gamma_index(
+			ExecutionPolicy policy,
+			image_data<Type, 1>& gamma_index_output,
+			const image_data<Type, 1>& reference_doses,
+			const image_coordinates<Type, 1>& reference_x_coordinates,
+			const image_data<Type, 1>& target_doses,
+			const image_coordinates<Type, 1>& target_x_coordinate,
+			const global_gamma_index_params<Type>& params
+		)
+		{
+			return gamma_index_minimize_pass(
+				policy,
+				gamma_index_output.data(), gamma_index_output.data() + gamma_index_output.total_size(),
+				reference_doses.data(),
+				array<const_view<Type>, 1>{ reference_x_coordinates.data() },
+				target_doses.data(), target_doses.data() + target_doses.total_size(),
+				array<const_view<Type>, 1>{ target_x_coordinate.data() },
+				params);
+		}
+
+		template<typename Type, typename ExecutionPolicy>
+		error_code gamma_index(
+			ExecutionPolicy policy,
+			image_data<Type, 2>& gamma_index_output,
+			const image_data<Type, 2>& reference_doses,
+			const image_coordinates<Type, 2>& reference_x_coordinates, const image_coordinates<Type, 2>& reference_y_coordinates,
+			const image_data<Type, 2>& target_doses,
+			const image_coordinates<Type, 2>& target_x_coordinate, const image_coordinates<Type, 2>& target_y_coordinate,
+			const global_gamma_index_params<Type>& params
+		)
+		{
+			return gamma_index_minimize_pass(
+				policy,
+				gamma_index_output.data(), gamma_index_output.data() + gamma_index_output.total_size(),
+				reference_doses.data(),
+				array<const_view<Type>, 2>{ reference_x_coordinates.data(), reference_y_coordinates.data() },
+				target_doses.data(), target_doses.data() + target_doses.total_size(),
+				array<const_view<Type>, 2>{ target_x_coordinate.data(), target_y_coordinate.data() },
+				params);
+		}
+
+		template<typename Type, typename ExecutionPolicy>
+		error_code gamma_index(
+			ExecutionPolicy policy,
+			image_data<Type, 3>& gamma_index_output,
+			const image_data<Type, 3>& reference_doses,
+			const image_coordinates<Type, 3>& reference_x_coordinates, const image_coordinates<Type, 3>& reference_y_coordinates, const image_coordinates<Type, 3>& reference_z_coordinates,
+			const image_data<Type, 3>& target_doses,
+			const image_coordinates<Type, 3>& target_x_coordinate, const image_coordinates<Type, 3>& target_y_coordinate, const image_coordinates<Type, 3>& target_z_coordinate,
+			const global_gamma_index_params<Type>& params
+		)
+		{
+			return gamma_index_minimize_pass(
+				policy,
+				gamma_index_output.data(), gamma_index_output.data() + gamma_index_output.total_size(),
+				reference_doses.data(),
+				array<const_view<Type>, 3>{ reference_x_coordinates.data(), reference_y_coordinates.data(), reference_z_coordinates.data() },
+				target_doses.data(), target_doses.data() + target_doses.total_size(),
+				array<const_view<Type>, 3>{ target_x_coordinate.data(), target_y_coordinate.data(), target_z_coordinate.data() },
+				params);
+		}
+
+		// -------- reference image_data, image_coordinates, target as iimage --------
+
+		constexpr size_t splitting_factor = 2;
+
+		constexpr std::array<data_region<1>, splitting_factor> split_region(const data_region<1>& current_region)
+		{
+			data_region<1> r0{ {0},{current_region.size.sizes[0] / splitting_factor} };
+			data_region<1> r1{ {r0.size.sizes[0]},{current_region.size.sizes[0] - r0.size.sizes[0]} };
+
+			return { r0,r1 };
+		}
+
+		constexpr std::array<data_region<2>, splitting_factor * splitting_factor> split_region(const data_region<2>& current_region)
+		{
+			data_region<2> r00{ {0,0},{current_region.size.sizes[0] / splitting_factor, current_region.size.sizes[1] / splitting_factor} };
+			data_region<2> r01{ {r00.size.sizes[0], 0},{current_region.size.sizes[0] - r00.size.sizes[0], r00.size.sizes[1]} };
+			data_region<2> r10{ {0, r00.size.sizes[1]},{r00.size.sizes[0], current_region.size.sizes[1] - r00.size.sizes[1]} };
+			data_region<2> r11{ {r01.offset.offset[0], r10.offset.offset[1]},{r01.size.sizes[0], r10.size.sizes[1]} };
+
+			return { r00,r01,r10,r11 };
+		}
+
+		constexpr std::array<data_region<3>, splitting_factor * splitting_factor * splitting_factor> split_region(const data_region<3>& current_region)
+		{
+			data_region<3> r000{ {0,0,0},{current_region.size.sizes[0] / splitting_factor, current_region.size.sizes[1] / splitting_factor, current_region.size.sizes[2] / splitting_factor} };
+			data_region<3> r001{ {r000.size.sizes[0], 0, 0},{current_region.size.sizes[0] - r000.size.sizes[0], r000.size.sizes[1], r000.size.sizes[2]} };
+			data_region<3> r010{ {0, r000.size.sizes[1], 0},{r000.size.sizes[0], current_region.size.sizes[1] - r000.size.sizes[1], r000.size.sizes[2]} };
+			data_region<3> r011{ {r001.offset.offset[0], r010.offset.offset[1], 0},{r001.size.sizes[0], r010.size.sizes[1], r000.size.sizes[2]} };
+
+			data_region<3> r100{ {0,0,r000.size.sizes[2]},{r000.size.sizes[0], r000.size.sizes[0], current_region.size.sizes[2] - r000.size.sizes[2]} };
+			data_region<3> r101{ {r000.size.sizes[0], 0, r000.size.sizes[2]},{current_region.size.sizes[0] - r000.size.sizes[0], r000.size.sizes[1], r100.size.sizes[2]} };
+			data_region<3> r110{ {0, r000.size.sizes[1], r000.size.sizes[2]},{r000.size.sizes[0], current_region.size.sizes[1] - r000.size.sizes[1], r100.size.sizes[2]} };
+			data_region<3> r111{ {r001.offset.offset[0], r010.offset.offset[1], r000.size.sizes[2]},{r001.size.sizes[0], r010.size.sizes[1], r100.size.sizes[2]} };
+
+			return { r000,r001,r010,r011,r100,r101,r110,r111 };
+		}
+
+		template<typename ExecutionPolicy, typename Type, typename Allocator = std::allocator<Type>>
+		std::error_code gamma_index(
+			ExecutionPolicy policy,
+			image_data<Type, 1>& gamma_index_output,
+			const image_data<Type, 1>& reference_doses,
+			const image_coordinates<Type, 1>& reference_x_coordinates,
+			const irtdose_image_region<Type, 1>& target,
+			const local_gamma_index_params<Type>& params,
+			Allocator allocator = Allocator())
+		{
+			if (detail::gamma_index_should_split(target.region()))
+			{
+				for (const auto& region : split_region(target.region()))
+				{
+					std::error_code error;
+
+					auto target_subregion = target.subregion(region, error);
+					if (!target_subregion) return error;
+
+					error = gamma_index(
+						policy,
+						gamma_index_output,
+						reference_doses,
+						reference_x_coordinates,
+						*target_subregion,
+						params,
+						allocator
+					);
+					if (error) return error;
+				}
+				return {};
+			}
+			else
+			{
+				std::error_code error = {};
+
+				auto t_doses = target.load(target.preferred_data_format(), allocator, error);
+				if (!t_doses) return error;
+
+				auto t_x_coords = target.template load_coordinates<0>(target.template preferred_coordinates_format<0>(), allocator, error);
+				if (!t_x_coords) return error;
+
+
+				gamma_index(
+					policy,
+					gamma_index_output,
+					reference_doses,
+					reference_x_coordinates,
+					*t_doses,
+					*t_x_coords,
+					params);
+
+				return {};
+			}
+		}
+
+		template<typename ExecutionPolicy, typename Type, typename Allocator = std::allocator<Type>>
+		std::error_code gamma_index(
+			ExecutionPolicy policy,
+			image_data<Type, 2>& gamma_index_output,
+			const image_data<Type, 2>& reference_doses,
+			const image_coordinates<Type, 2>& reference_x_coordinates, const image_coordinates<Type, 2>& reference_y_coordinates,
+			const irtdose_image_region<Type, 2>& target,
+			const local_gamma_index_params<Type>& params,
+			Allocator allocator = Allocator())
+		{
+			if (detail::gamma_index_should_split(target.region()))
+			{
+				for (const auto& region : split_region(target.region()))
+				{
+					std::error_code error;
+
+					auto target_subregion = target.subregion(region, error);
+					if (!target_subregion) return error;
+
+					error = gamma_index(
+						policy,
+						gamma_index_output,
+						reference_doses,
+						reference_x_coordinates, reference_y_coordinates,
+						*target_subregion,
+						params,
+						allocator
+					);
+					if (error) return error;
+				}
+				return {};
+			}
+			else
+			{
+				std::error_code error = {};
+
+				auto t_doses = target.load(target.preferred_data_format(), allocator, error);
+				if (!t_doses) return error;
+
+				auto t_x_coords = target.template load_coordinates<0>(target.template preferred_coordinates_format<0>(), allocator, error);
+				if (!t_x_coords) return error;
+
+				auto t_y_coords = target.template load_coordinates<1>(target.template preferred_coordinates_format<1>(), allocator, error);
+				if (!t_y_coords) return error;
+
+				gamma_index(
+					policy,
+					gamma_index_output,
+					reference_doses,
+					reference_x_coordinates, reference_y_coordinates,
+					*t_doses,
+					*t_x_coords, *t_y_coords,
+					params);
+
+				return {};
+			}
+		}
+
+		template<typename ExecutionPolicy, typename Type, typename Allocator = std::allocator<Type>>
+		std::error_code gamma_index(
+			ExecutionPolicy policy,
+			image_data<Type, 3>& gamma_index_output,
+			const image_data<Type, 3>& reference_doses,
+			const image_coordinates<Type, 3>& reference_x_coordinates, const image_coordinates<Type, 3>& reference_y_coordinates, const image_coordinates<Type, 3>& reference_z_coordinates,
+			const irtdose_image_region<Type, 3>& target,
+			const local_gamma_index_params<Type>& params,
+			Allocator allocator = Allocator())
+		{
+			if (detail::gamma_index_should_split(target.region()))
+			{
+				for (const auto& region : split_region(target.region()))
+				{
+					std::error_code error;
+
+					auto target_subregion = target.subregion(region, error);
+					if (!target_subregion) return error;
+
+					error = gamma_index(
+						policy,
+						gamma_index_output,
+						reference_doses,
+						reference_x_coordinates, reference_y_coordinates, reference_z_coordinates,
+						*target_subregion,
+						params,
+						allocator
+					);
+					if (error) return error;
+				}
+				return {};
+			}
+			else
+			{
+				std::error_code error = {};
+
+				auto t_doses = target.load(target.preferred_data_format(), allocator, error);
+				if (!t_doses) return error;
+
+				auto t_x_coords = target.template load_coordinates<0>(target.template preferred_coordinates_format<0>(), allocator, error);
+				if (!t_x_coords) return error;
+
+				auto t_y_coords = target.template load_coordinates<1>(target.template preferred_coordinates_format<1>(), allocator, error);
+				if (!t_y_coords) return error;
+
+				auto t_z_coords = target.template load_coordinates<2>(target.template preferred_coordinates_format<2>(), allocator, error);
+				if (!t_z_coords) return error;
+
+				gamma_index(
+					policy,
+					gamma_index_output,
+					reference_doses,
+					reference_x_coordinates, reference_y_coordinates, reference_z_coordinates,
+					*t_doses,
+					*t_x_coords, *t_y_coords, *t_z_coords,
+					params);
+
+				return {};
+			}
+		}
+
+		template<typename ExecutionPolicy, typename Type, typename Allocator = std::allocator<Type>>
+		std::error_code gamma_index(
+			ExecutionPolicy policy,
+			image_data<Type, 1>& gamma_index_output,
+			const image_data<Type, 1>& reference_doses,
+			const image_coordinates<Type, 1>& reference_x_coordinates,
+			const irtdose_image_region<Type, 1>& target,
+			const global_gamma_index_params<Type>& params,
+			Allocator allocator = Allocator())
+		{
+			if (detail::gamma_index_should_split(target.region()))
+			{
+				for (const auto& region : split_region(target.region()))
+				{
+					std::error_code error;
+
+					auto target_subregion = target.subregion(region, error);
+					if (!target_subregion) return error;
+
+					error = gamma_index(
+						policy,
+						gamma_index_output,
+						reference_doses,
+						reference_x_coordinates,
+						*target_subregion,
+						params,
+						allocator
+					);
+					if (error) return error;
+				}
+				return {};
+			}
+			else
+			{
+				std::error_code error = {};
+
+				auto t_doses = target.load(target.preferred_data_format(), allocator, error);
+				if (!t_doses) return error;
+
+				auto t_x_coords = target.template load_coordinates<0>(target.template preferred_coordinates_format<0>(), allocator, error);
+				if (!t_x_coords) return error;
+
+
+				gamma_index(
+					policy,
+					gamma_index_output,
+					reference_doses,
+					reference_x_coordinates,
+					*t_doses,
+					*t_x_coords,
+					params);
+
+				return {};
+			}
+		}
+
+		template<typename ExecutionPolicy, typename Type, typename Allocator = std::allocator<Type>>
+		std::error_code gamma_index(
+			ExecutionPolicy policy,
+			image_data<Type, 2>& gamma_index_output,
+			const image_data<Type, 2>& reference_doses,
+			const image_coordinates<Type, 2>& reference_x_coordinates, const image_coordinates<Type, 2>& reference_y_coordinates,
+			const irtdose_image_region<Type, 2>& target,
+			const global_gamma_index_params<Type>& params,
+			Allocator allocator = Allocator())
+		{
+			if (detail::gamma_index_should_split(target.region()))
+			{
+				for (const auto& region : split_region(target.region()))
+				{
+					std::error_code error;
+
+					auto target_subregion = target.subregion(region, error);
+					if (!target_subregion) return error;
+
+					error = gamma_index(
+						policy,
+						gamma_index_output,
+						reference_doses,
+						reference_x_coordinates, reference_y_coordinates,
+						*target_subregion,
+						params,
+						allocator
+					);
+					if (error) return error;
+				}
+				return {};
+			}
+			else
+			{
+				std::error_code error = {};
+
+				auto t_doses = target.load(target.preferred_data_format(), allocator, error);
+				if (!t_doses) return error;
+
+				auto t_x_coords = target.template load_coordinates<0>(target.template preferred_coordinates_format<0>(), allocator, error);
+				if (!t_x_coords) return error;
+
+				auto t_y_coords = target.template load_coordinates<1>(target.template preferred_coordinates_format<1>(), allocator, error);
+				if (!t_y_coords) return error;
+
+				gamma_index(
+					policy,
+					gamma_index_output,
+					reference_doses,
+					reference_x_coordinates, reference_y_coordinates,
+					*t_doses,
+					*t_x_coords, *t_y_coords,
+					params);
+
+				return {};
+			}
+		}
+
+		template<typename ExecutionPolicy, typename Type, typename Allocator = std::allocator<Type>>
+		std::error_code gamma_index(
+			ExecutionPolicy policy,
+			image_data<Type, 3>& gamma_index_output,
+			const image_data<Type, 3>& reference_doses,
+			const image_coordinates<Type, 3>& reference_x_coordinates, const image_coordinates<Type, 3>& reference_y_coordinates, const image_coordinates<Type, 3>& reference_z_coordinates,
+			const irtdose_image_region<Type, 3>& target,
+			const global_gamma_index_params<Type>& params,
+			Allocator allocator = Allocator())
+		{
+			if (detail::gamma_index_should_split(target.region()))
+			{
+				for (const auto& region : split_region(target.region()))
+				{
+					std::error_code error;
+
+					auto target_subregion = target.subregion(region, error);
+					if (!target_subregion) return error;
+
+					error = gamma_index(
+						policy,
+						gamma_index_output,
+						reference_doses,
+						reference_x_coordinates, reference_y_coordinates, reference_z_coordinates,
+						*target_subregion,
+						params,
+						allocator
+					);
+					if (error) return error;
+				}
+				return {};
+			}
+			else
+			{
+				std::error_code error = {};
+
+				auto t_doses = target.load(target.preferred_data_format(), allocator, error);
+				if (!t_doses) return error;
+
+				auto t_x_coords = target.template load_coordinates<0>(target.template preferred_coordinates_format<0>(), allocator, error);
+				if (!t_x_coords) return error;
+
+				auto t_y_coords = target.template load_coordinates<1>(target.template preferred_coordinates_format<1>(), allocator, error);
+				if (!t_y_coords) return error;
+
+				auto t_z_coords = target.template load_coordinates<2>(target.template preferred_coordinates_format<2>(), allocator, error);
+				if (!t_z_coords) return error;
+
+				gamma_index(
+					policy,
+					gamma_index_output,
+					reference_doses,
+					reference_x_coordinates, reference_y_coordinates, reference_z_coordinates,
+					*t_doses,
+					*t_x_coords, *t_y_coords, *t_z_coords,
+					params);
+
+				return {};
+			}
+		}
+	}
+
+	template<typename ExecutionPolicy, typename Type, typename Allocator = std::allocator<Type>>
+	error_code gamma_index(
+		ExecutionPolicy policy,
+		iwritable_image_region<Type, 1>& gamma_index_output,
+		const irtdose_image_region<Type, 1>& reference, const irtdose_image_region<Type, 1>& target,
+		const local_gamma_index_params<Type>& params,
+		Allocator allocator = Allocator())
+	{
+		if (gamma_index_output.region() != reference.region())
+			return {};//some error code
+
+		if (detail::gamma_index_should_split(reference.region()))
+		{
+			for (const auto& region : detail::split_region(reference.region()))
+			{
+				std::error_code error;
+
+				auto gamma_index_output_subregion = gamma_index_output.subregion(region, error);
+				if (!gamma_index_output_subregion) return error;
+
+				auto reference_subregion = target.subregion(region, error);
+				if (!reference_subregion) return error;
+
+				error = gamma_index(
+					policy,
+					*gamma_index_output_subregion,
+					*reference_subregion,
+					target,
+					params,
+					allocator
+				);
+				if (error) return error;
+			}
+			return {};
+		}
+		else
+		{
+			std::error_code error = {};
+
+			auto gi_output = gamma_index_output.load(gamma_index_output.preferred_data_format(), allocator, error);
+			if (!gi_output) return error;
+
+			error = detail::gamma_index_initialize_pass<1>(policy, gi_output->data(), gi_output->data() + gi_output->real_total_size());
+			if (error) return error;
+
+			auto r_doses = reference.load(reference.preferred_data_format(), allocator, error);
+			if (!r_doses) return error;
+
+			auto r_x_coords = reference.template load_coordinates<0>(reference.template preferred_coordinates_format<0>(), allocator, error);
+			if (!r_x_coords) return error;
+
+			error = detail::gamma_index(
+				policy,
+				*gi_output,
+				*r_doses,
+				*r_x_coords,
+				target,
+				params,
+				allocator);
+			if (error) return error;
+
+			error = detail::gamma_index_finalize_pass<1>(policy, gi_output->data(), gi_output->data() + gi_output->real_total_size());
+			if (error) return error;
+
+			return gamma_index_output.save(*gi_output);
+		}
+	}
+
+	template<typename ExecutionPolicy, typename Type, typename Allocator = std::allocator<Type>>
+	error_code gamma_index(
+		ExecutionPolicy policy,
+		iwritable_image_region<Type, 2>& gamma_index_output,
+		const irtdose_image_region<Type, 2>& reference, const irtdose_image_region<Type, 2>& target,
+		const local_gamma_index_params<Type>& params,
+		Allocator allocator = Allocator())
+	{
+		if (gamma_index_output.region() != reference.region())
+			return {};//some error code
+
+		if (detail::gamma_index_should_split(reference.region()))
+		{
+			for (const auto& region : detail::split_region(reference.region()))
+			{
+				std::error_code error;
+
+				auto gamma_index_output_subregion = gamma_index_output.subregion(region, error);
+				if (!gamma_index_output_subregion) return error;
+
+				auto reference_subregion = target.subregion(region, error);
+				if (!reference_subregion) return error;
+
+				error = gamma_index(
+					policy,
+					*gamma_index_output_subregion,
+					*reference_subregion,
+					target,
+					params,
+					allocator
+				);
+				if (error) return error;
+			}
+			return {};
+		}
+		else
+		{
+			std::error_code error = {};
+
+			auto gi_output = gamma_index_output.load(gamma_index_output.preferred_data_format(), allocator, error);
+			if (!gi_output) return error;
+
+			error = detail::gamma_index_initialize_pass<2>(policy, gi_output->data(), gi_output->data() + gi_output->real_total_size());
+			if (error) return error;
+
+			auto r_doses = reference.load(reference.preferred_data_format(), allocator, error);
+			if (!r_doses) return error;
+
+			auto r_x_coords = reference.template load_coordinates<0>(reference.template preferred_coordinates_format<0>(), allocator, error);
+			if (!r_x_coords) return error;
+
+			auto r_y_coords = reference.template load_coordinates<1>(reference.template preferred_coordinates_format<1>(), allocator, error);
+			if (!r_y_coords) return error;
+
+			error = detail::gamma_index(
+				policy,
+				*gi_output,
+				*r_doses,
+				*r_x_coords, *r_y_coords,
+				target,
+				params,
+				allocator);
+			if (error) return error;
+
+			error = detail::gamma_index_finalize_pass<2>(policy, gi_output->data(), gi_output->data() + gi_output->real_total_size());
+			if (error) return error;
+
+			return gamma_index_output.save(*gi_output);
+		}
+	}
+
+	template<typename ExecutionPolicy, typename Type, typename Allocator = std::allocator<Type>>
+	error_code gamma_index(
+		ExecutionPolicy policy,
+		iwritable_image_region<Type, 3>& gamma_index_output,
+		const irtdose_image_region<Type, 3>& reference, const irtdose_image_region<Type, 3>& target,
+		const local_gamma_index_params<Type>& params,
+		Allocator allocator = Allocator())
+	{
+		if (gamma_index_output.region() != reference.region())
+			return {};//some error code
+
+		if (detail::gamma_index_should_split(reference.region()))
+		{
+			for (const auto& region : detail::split_region(reference.region()))
+			{
+				std::error_code error;
+
+				auto gamma_index_output_subregion = gamma_index_output.subregion(region, error);
+				if (!gamma_index_output_subregion) return error;
+
+				auto reference_subregion = target.subregion(region, error);
+				if (!reference_subregion) return error;
+
+				error = gamma_index(
+					policy,
+					*gamma_index_output_subregion,
+					*reference_subregion,
+					target,
+					params,
+					allocator
+				);
+				if (error) return error;
+			}
+			return {};
+		}
+		else
+		{
+			std::error_code error = {};
+
+			auto gi_output = gamma_index_output.load(gamma_index_output.preferred_data_format(), allocator, error);
+			if (!gi_output) return error;
+
+			error = detail::gamma_index_initialize_pass<3>(policy, gi_output->data(), gi_output->data() + gi_output->real_total_size());
+			if (error) return error;
+
+			auto r_doses = reference.load(reference.preferred_data_format(), allocator, error);
+			if (!r_doses) return error;
+
+			auto r_x_coords = reference.template load_coordinates<0>(reference.template preferred_coordinates_format<0>(), allocator, error);
+			if (!r_x_coords) return error;
+
+			auto r_y_coords = reference.template load_coordinates<1>(reference.template preferred_coordinates_format<1>(), allocator, error);
+			if (!r_y_coords) return error;
+
+			auto r_z_coords = reference.template load_coordinates<2>(reference.template preferred_coordinates_format<2>(), allocator, error);
+			if (!r_z_coords) return error;
+
+			error = detail::gamma_index(
+				policy,
+				*gi_output,
+				*r_doses,
+				*r_x_coords, *r_y_coords, *r_z_coords,
+				target,
+				params,
+				allocator);
+			if (error) return error;
+
+			error = detail::gamma_index_finalize_pass<3>(policy, gi_output->data(), gi_output->data() + gi_output->real_total_size());
+			if (error) return error;
+
+			return gamma_index_output.save(*gi_output);
+		}
+	}
+
+	template<typename ExecutionPolicy, typename Type, typename Allocator = std::allocator<Type>>
+	error_code gamma_index(
+		ExecutionPolicy policy,
+		iwritable_image_region<Type, 1>& gamma_index_output,
+		const irtdose_image_region<Type, 1>& reference, const irtdose_image_region<Type, 1>& target,
+		const global_gamma_index_params<Type>& params,
+		Allocator allocator = Allocator())
+	{
+		if (gamma_index_output.region() != reference.region())
+			return {};//some error code
+
+		if (detail::gamma_index_should_split(reference.region()))
+		{
+			for (const auto& region : detail::split_region(reference.region()))
+			{
+				std::error_code error;
+
+				auto gamma_index_output_subregion = gamma_index_output.subregion(region, error);
+				if (!gamma_index_output_subregion) return error;
+
+				auto reference_subregion = target.subregion(region, error);
+				if (!reference_subregion) return error;
+
+				error = gamma_index(
+					policy,
+					*gamma_index_output_subregion,
+					*reference_subregion,
+					target,
+					params,
+					allocator
+				);
+				if (error) return error;
+			}
+			return {};
+		}
+		else
+		{
+			std::error_code error = {};
+
+			auto gi_output = gamma_index_output.load(gamma_index_output.preferred_data_format(), allocator, error);
+			if (!gi_output) return error;
+
+			error = detail::gamma_index_initialize_pass<1>(policy, gi_output->data(), gi_output->data() + gi_output->real_total_size());
+			if (error) return error;
+
+			auto r_doses = reference.load(reference.preferred_data_format(), allocator, error);
+			if (!r_doses) return error;
+
+			auto r_x_coords = reference.template load_coordinates<0>(reference.template preferred_coordinates_format<0>(), allocator, error);
+			if (!r_x_coords) return error;
+
+			error = detail::gamma_index(
+				policy,
+				*gi_output,
+				*r_doses,
+				*r_x_coords,
+				target,
+				params,
+				allocator);
+			if (error) return error;
+
+			error = detail::gamma_index_finalize_pass<1>(policy, gi_output->data(), gi_output->data() + gi_output->real_total_size());
+			if (error) return error;
+
+			return gamma_index_output.save(*gi_output);
+		}
+	}
+
+	template<typename ExecutionPolicy, typename Type, typename Allocator = std::allocator<Type>>
+	error_code gamma_index(
+		ExecutionPolicy policy,
+		iwritable_image_region<Type, 2>& gamma_index_output,
+		const irtdose_image_region<Type, 2>& reference, const irtdose_image_region<Type, 2>& target,
+		const global_gamma_index_params<Type>& params,
+		Allocator allocator = Allocator())
+	{
+		if (gamma_index_output.region() != reference.region())
+			return {};//some error code
+
+		if (detail::gamma_index_should_split(reference.region()))
+		{
+			for (const auto& region : detail::split_region(reference.region()))
+			{
+				std::error_code error;
+
+				auto gamma_index_output_subregion = gamma_index_output.subregion(region, error);
+				if (!gamma_index_output_subregion) return error;
+
+				auto reference_subregion = target.subregion(region, error);
+				if (!reference_subregion) return error;
+
+				error = gamma_index(
+					policy,
+					*gamma_index_output_subregion,
+					*reference_subregion,
+					target,
+					params,
+					allocator
+				);
+				if (error) return error;
+			}
+			return {};
+		}
+		else
+		{
+			std::error_code error = {};
+
+			auto gi_output = gamma_index_output.load(gamma_index_output.preferred_data_format(), allocator, error);
+			if (!gi_output) return error;
+
+			error = detail::gamma_index_initialize_pass<2>(policy, gi_output->data(), gi_output->data() + gi_output->real_total_size());
+			if (error) return error;
+
+			auto r_doses = reference.load(reference.preferred_data_format(), allocator, error);
+			if (!r_doses) return error;
+
+			auto r_x_coords = reference.template load_coordinates<0>(reference.template preferred_coordinates_format<0>(), allocator, error);
+			if (!r_x_coords) return error;
+
+			auto r_y_coords = reference.template load_coordinates<1>(reference.template preferred_coordinates_format<1>(), allocator, error);
+			if (!r_y_coords) return error;
+
+			error = detail::gamma_index(
+				policy,
+				*gi_output,
+				*r_doses,
+				*r_x_coords, *r_y_coords,
+				target,
+				params,
+				allocator);
+			if (error) return error;
+
+			error = detail::gamma_index_finalize_pass<2>(policy, gi_output->data(), gi_output->data() + gi_output->real_total_size());
+			if (error) return error;
+
+			return gamma_index_output.save(*gi_output);
+		}
+	}
+
+	template<typename ExecutionPolicy, typename Type, typename Allocator = std::allocator<Type>>
+	error_code gamma_index(
+		ExecutionPolicy policy,
+		iwritable_image_region<Type, 3>& gamma_index_output,
+		const irtdose_image_region<Type, 3>& reference, const irtdose_image_region<Type, 3>& target,
+		const global_gamma_index_params<Type>& params,
+		Allocator allocator = Allocator())
+	{
+		if (gamma_index_output.region() != reference.region())
+			return {};//some error code
+
+		if (detail::gamma_index_should_split(reference.region()))
+		{
+			for (const auto& region : detail::split_region(reference.region()))
+			{
+				std::error_code error;
+
+				auto gamma_index_output_subregion = gamma_index_output.subregion(region, error);
+				if (!gamma_index_output_subregion) return error;
+
+				auto reference_subregion = target.subregion(region, error);
+				if (!reference_subregion) return error;
+
+				error = gamma_index(
+					policy,
+					*gamma_index_output_subregion,
+					*reference_subregion,
+					target,
+					params,
+					allocator
+				);
+				if (error) return error;
+			}
+			return {};
+		}
+		else
+		{
+			std::error_code error = {};
+
+			auto gi_output = gamma_index_output.load(gamma_index_output.preferred_data_format(), allocator, error);
+			if (!gi_output) return error;
+
+			error = detail::gamma_index_initialize_pass<3>(policy, gi_output->data(), gi_output->data() + gi_output->real_total_size());
+			if (error) return error;
+
+			auto r_doses = reference.load(reference.preferred_data_format(), allocator, error);
+			if (!r_doses) return error;
+
+			auto r_x_coords = reference.template load_coordinates<0>(reference.template preferred_coordinates_format<0>(), allocator, error);
+			if (!r_x_coords) return error;
+
+			auto r_y_coords = reference.template load_coordinates<1>(reference.template preferred_coordinates_format<1>(), allocator, error);
+			if (!r_y_coords) return error;
+
+			auto r_z_coords = reference.template load_coordinates<2>(reference.template preferred_coordinates_format<2>(), allocator, error);
+			if (!r_z_coords) return error;
+
+			error = detail::gamma_index(
+				policy,
+				*gi_output,
+				*r_doses,
+				*r_x_coords, *r_y_coords, *r_z_coords,
+				target,
+				params,
+				allocator);
+			if (error) return error;
+
+			error = detail::gamma_index_finalize_pass<3>(policy, gi_output->data(), gi_output->data() + gi_output->real_total_size());
+			if (error) return error;
+
+			return gamma_index_output.save(*gi_output);
+		}
+	}
+}

--- a/gi_core/include/math/vectorized/common.hpp
+++ b/gi_core/include/math/vectorized/common.hpp
@@ -1,0 +1,210 @@
+#pragma once
+
+#include <math/common.hpp>
+
+#include <simdpp/simd.h>
+
+namespace yagit::core::math::vectorized
+{
+	template<typename Type, unsigned VectorSize>
+	struct vlocal_gamma_index_params {};
+
+	template<unsigned VectorSize>
+	struct vlocal_gamma_index_params<float, VectorSize>
+	{
+		using value_type = float;
+		using vector_type = simdpp::float32<VectorSize>;
+		static constexpr size_t vector_size = VectorSize;
+
+		vlocal_gamma_index_params(const local_gamma_index_params<value_type>& params)
+			: percentage(simdpp::load_splat(&params.percentage))
+			, distance_to_agreement_squared(simdpp::load_splat(&params.distance_to_agreement_squared))
+		{
+		}
+
+		vector_type percentage;
+		vector_type distance_to_agreement_squared;
+	};
+
+	template<unsigned VectorSize>
+	struct vlocal_gamma_index_params<double, VectorSize>
+	{
+		using value_type = double;
+		using vector_type = simdpp::float64<VectorSize>;
+		static constexpr size_t vector_size = VectorSize;
+
+		vlocal_gamma_index_params(const local_gamma_index_params<value_type> & params)
+			: percentage(simdpp::load_splat(&params.percentage))
+			, distance_to_agreement_squared(simdpp::load_splat(&params.distance_to_agreement_squared))
+		{
+		}
+
+		vector_type percentage;
+		vector_type distance_to_agreement_squared;
+	};
+
+	template<typename Type, unsigned VectorSize>
+	struct vglobal_gamma_index_params {};
+
+	template<unsigned VectorSize>
+	struct vglobal_gamma_index_params<float, VectorSize>
+	{
+		using value_type = float;
+		using vector_type = simdpp::float32<VectorSize>;
+		static constexpr size_t vector_size = VectorSize;
+
+		vglobal_gamma_index_params(const global_gamma_index_params<value_type>& params)
+			: dose_difference_squared(simdpp::load_splat(&params.dose_difference_squared))
+			, distance_to_agreement_squared(simdpp::load_splat(&params.distance_to_agreement_squared))
+		{
+		}
+
+		vector_type dose_difference_squared;
+		vector_type distance_to_agreement_squared;
+	};
+
+	template<unsigned VectorSize>
+	struct vglobal_gamma_index_params<double, VectorSize>
+	{
+		using value_type = double;
+		using vector_type = simdpp::float64<VectorSize>;
+		static constexpr size_t vector_size = VectorSize;
+
+		vglobal_gamma_index_params(const global_gamma_index_params<value_type>& params)
+			: dose_difference_squared(simdpp::load_splat(&params.dose_difference_squared))
+			, distance_to_agreement_squared(simdpp::load_splat(&params.distance_to_agreement_squared))
+		{
+		}
+
+		vector_type dose_difference_squared;
+		vector_type distance_to_agreement_squared;
+	};
+
+	template<typename T, unsigned VectorSize>
+	struct vgamma_index_params {};
+
+	template<unsigned VectorSize>
+	struct vgamma_index_params<float, VectorSize> 
+	{
+		using value_type = float;
+		using vector_type = simdpp::float32<VectorSize>;
+		static constexpr size_t vector_size = VectorSize;
+		using variant_type = variant<vlocal_gamma_index_params<value_type, VectorSize>, vglobal_gamma_index_params<value_type, VectorSize>>;
+
+		vgamma_index_params(const gamma_index_params<value_type>& params_)
+			: params(std::visit([](auto&& param) -> variant_type {return param; }, params_.params))
+		{
+		}
+
+		variant_type params;
+	};
+
+	template<unsigned VectorSize>
+	struct vgamma_index_params<double, VectorSize>
+	{
+		using value_type = double;
+		using vector_type = simdpp::float64<VectorSize>;
+		static constexpr size_t vector_size = VectorSize;
+		using variant_type = variant<vlocal_gamma_index_params<value_type, VectorSize>, vglobal_gamma_index_params<value_type, VectorSize>>;
+
+		vgamma_index_params(const gamma_index_params<value_type>& params_)
+			: params(std::visit([](auto&& param) -> variant_type {return param; }, params_.params))
+		{
+		}
+
+		variant_type params;
+	};
+
+	template<typename Type, unsigned VectorSize>
+	struct vec {};
+
+	template<unsigned VectorSize>
+	struct vec<float, VectorSize> { using type = simdpp::float32<VectorSize>; };
+
+	template<unsigned VectorSize>
+	struct vec<double, VectorSize> { using type = simdpp::float64<VectorSize>; };
+
+	template<typename Type, unsigned VectorSize>
+	using vec_t = typename vec<Type, VectorSize>::type;
+
+	template<typename ParamsType, unsigned VectorSize>
+	struct params_vec {};
+
+	template<typename Type, unsigned VectorSize>
+	struct params_vec<local_gamma_index_params<Type>, VectorSize> { using type = vlocal_gamma_index_params<Type, VectorSize>; };
+
+	template<typename Type, unsigned VectorSize>
+	struct params_vec<global_gamma_index_params<Type>, VectorSize> { using type = vglobal_gamma_index_params<Type, VectorSize>; };
+
+	template<typename Type, unsigned VectorSize>
+	struct params_vec<gamma_index_params<Type>, VectorSize> { using type = vgamma_index_params<Type, VectorSize>; };
+
+	template<typename ParamsType, unsigned VectorSize>
+	using params_vec_t = typename params_vec<ParamsType, VectorSize>::type;
+
+	template<bool Alignment, typename Type>
+	auto load(const Type* p)
+	{
+		if constexpr (Alignment)
+			return simdpp::load(p);
+		else
+			return simdpp::load_u(p);
+	}
+
+	template<bool Alignment, unsigned N, typename Type, typename E>
+	void store(Type* p, const simdpp::any_vec<N, E>& v)
+	{
+		if constexpr (Alignment)
+			simdpp::store(p, v);
+		else
+			simdpp::store_u(p, v);
+	}
+
+	namespace detail
+	{
+		template<unsigned VectorSize, typename F>
+		inline float find_if(const simdpp::float32<VectorSize>& v, F f, index_sequence<>)
+		{
+			return std::nanf("");
+		}
+
+		template<unsigned VectorSize, typename F, size_t I0, size_t... I>
+		inline float find_if(const simdpp::float32<VectorSize>& v, F f, index_sequence<I0, I...>)
+		{
+			auto value = simdpp::extract<I0>(v);
+			if (f(value))
+				return value;
+			else
+				return find_if(v, f, index_sequence<I...>{});
+		}
+
+		template<unsigned VectorSize, typename F>
+		inline double find_if(const simdpp::float64<VectorSize>& v, F f, index_sequence<>)
+		{
+			return std::nan("");
+		}
+
+		template<unsigned VectorSize, typename F, size_t I0, size_t... I>
+		inline double find_if(const simdpp::float64<VectorSize>& v, F f, index_sequence<I0, I...>)
+		{
+			auto value = simdpp::extract<I0>(v);
+			if (f(value))
+				return value;
+			else
+				return find_if(v, f, index_sequence<I...>{});
+		}
+	}
+	
+
+	template<unsigned VectorSize, typename F>
+	inline float find_if(const simdpp::float32<VectorSize>& v, F f)
+	{
+		return detail::find_if(v, f, make_index_sequence<VectorSize>());
+	}
+
+	template<unsigned VectorSize, typename F>
+	inline double find_if(const simdpp::float64<VectorSize>& v, F f)
+	{
+		return detail::find_if(v, f, make_index_sequence<VectorSize>());
+	}
+}

--- a/gi_core/include/math/vectorized/gamma_index_range.hpp
+++ b/gi_core/include/math/vectorized/gamma_index_range.hpp
@@ -1,0 +1,153 @@
+#pragma once
+
+#include <math/vectorized/common.hpp>
+
+#include <math/basic/gamma_index_range.hpp>
+
+namespace yagit::core::math
+{
+	template<typename Type, size_t Dimensions>
+	struct unsequenced_gamma_index_implementer : public sequenced_gamma_index_implementer<Type, Dimensions> {};
+
+	// -------- float32 --------
+
+	template<>
+	struct unsequenced_gamma_index_implementer<float, 1>
+	{
+		using value_type = float;
+
+		static error_code initialize_pass(view<value_type> output, view<value_type> output_end);
+		static error_code minimize_pass(
+			view<value_type> output, view<value_type> output_end,
+			const_view<value_type> reference_doses,
+			array<const_view<value_type>, 1> reference_coordinates,
+			const_view<value_type> target_doses, const_view<value_type> target_doses_end,
+			array<const_view<value_type>, 1> target_coordinates,
+			const local_gamma_index_params<value_type>& params);
+		static error_code minimize_pass(
+			view<value_type> output, view<value_type> output_end,
+			const_view<value_type> reference_doses,
+			array<const_view<value_type>, 1> reference_coordinates,
+			const_view<value_type> target_doses, const_view<value_type> target_doses_end,
+			array<const_view<value_type>, 1> target_coordinates,
+			const global_gamma_index_params<value_type>& params);
+		static error_code finalize_pass(view<value_type> output, view<value_type> output_end);
+	};
+
+	template<>
+	struct unsequenced_gamma_index_implementer<float, 2>
+	{
+		using value_type = float;
+
+		static error_code initialize_pass(view<value_type> output, view<value_type> output_end);
+		static error_code minimize_pass(
+			view<value_type> output, view<value_type> output_end,
+			const_view<value_type> reference_doses,
+			array<const_view<value_type>, 2> reference_coordinates,
+			const_view<value_type> target_doses, const_view<value_type> target_doses_end,
+			array<const_view<value_type>, 2> target_coordinates,
+			const local_gamma_index_params<value_type>& params);
+		static error_code minimize_pass(
+			view<value_type> output, view<value_type> output_end,
+			const_view<value_type> reference_doses,
+			array<const_view<value_type>, 2> reference_coordinates,
+			const_view<value_type> target_doses, const_view<value_type> target_doses_end,
+			array<const_view<value_type>, 2> target_coordinates,
+			const global_gamma_index_params<value_type>& params);
+		static error_code finalize_pass(view<value_type> output, view<value_type> output_end);
+	};
+
+	template<>
+	struct unsequenced_gamma_index_implementer<float, 3>
+	{
+		using value_type = float;
+
+		static error_code initialize_pass(view<value_type> output, view<value_type> output_end);
+		static error_code minimize_pass(
+			view<value_type> output, view<value_type> output_end,
+			const_view<value_type> reference_doses,
+			array<const_view<value_type>, 3> reference_coordinates,
+			const_view<value_type> target_doses, const_view<value_type> target_doses_end,
+			array<const_view<value_type>, 3> target_coordinates,
+			const local_gamma_index_params<value_type>& params);
+		static error_code minimize_pass(
+			view<value_type> output, view<value_type> output_end,
+			const_view<value_type> reference_doses,
+			array<const_view<value_type>, 3> reference_coordinates,
+			const_view<value_type> target_doses, const_view<value_type> target_doses_end,
+			array<const_view<value_type>, 3> target_coordinates,
+			const global_gamma_index_params<value_type>& params);
+		static error_code finalize_pass(view<value_type> output, view<value_type> output_end);
+	};
+
+	// -------- float64 --------
+
+	template<>
+	struct unsequenced_gamma_index_implementer<double, 1>
+	{
+		using value_type = double;
+
+		static error_code initialize_pass(view<value_type> output, view<value_type> output_end);
+		static error_code minimize_pass(
+			view<value_type> output, view<value_type> output_end,
+			const_view<value_type> reference_doses,
+			array<const_view<value_type>, 1> reference_coordinates,
+			const_view<value_type> target_doses, const_view<value_type> target_doses_end,
+			array<const_view<value_type>, 1> target_coordinates,
+			const local_gamma_index_params<value_type>& params);
+		static error_code minimize_pass(
+			view<value_type> output, view<value_type> output_end,
+			const_view<value_type> reference_doses,
+			array<const_view<value_type>, 1> reference_coordinates,
+			const_view<value_type> target_doses, const_view<value_type> target_doses_end,
+			array<const_view<value_type>, 1> target_coordinates,
+			const global_gamma_index_params<value_type>& params);
+		static error_code finalize_pass(view<value_type> output, view<value_type> output_end);
+	};
+
+	template<>
+	struct unsequenced_gamma_index_implementer<double, 2>
+	{
+		using value_type = double;
+
+		static error_code initialize_pass(view<value_type> output, view<value_type> output_end);
+		static error_code minimize_pass(
+			view<value_type> output, view<value_type> output_end,
+			const_view<value_type> reference_doses,
+			array<const_view<value_type>, 2> reference_coordinates,
+			const_view<value_type> target_doses, const_view<value_type> target_doses_end,
+			array<const_view<value_type>, 2> target_coordinates,
+			const local_gamma_index_params<value_type>& params);
+		static error_code minimize_pass(
+			view<value_type> output, view<value_type> output_end,
+			const_view<value_type> reference_doses,
+			array<const_view<value_type>, 2> reference_coordinates,
+			const_view<value_type> target_doses, const_view<value_type> target_doses_end,
+			array<const_view<value_type>, 2> target_coordinates,
+			const global_gamma_index_params<value_type>& params);
+		static error_code finalize_pass(view<value_type> output, view<value_type> output_end);
+	};
+
+	template<>
+	struct unsequenced_gamma_index_implementer<double, 3>
+	{
+		using value_type = double;
+
+		static error_code initialize_pass(view<value_type> output, view<value_type> output_end);
+		static error_code minimize_pass(
+			view<value_type> output, view<value_type> output_end,
+			const_view<value_type> reference_doses,
+			array<const_view<value_type>, 3> reference_coordinates,
+			const_view<value_type> target_doses, const_view<value_type> target_doses_end,
+			array<const_view<value_type>, 3> target_coordinates,
+			const local_gamma_index_params<value_type>& params);
+		static error_code minimize_pass(
+			view<value_type> output, view<value_type> output_end,
+			const_view<value_type> reference_doses,
+			array<const_view<value_type>, 3> reference_coordinates,
+			const_view<value_type> target_doses, const_view<value_type> target_doses_end,
+			array<const_view<value_type>, 3> target_coordinates,
+			const global_gamma_index_params<value_type>& params);
+		static error_code finalize_pass(view<value_type> output, view<value_type> output_end);
+	};
+}

--- a/gi_core/include/math/vectorized/gamma_index_single.hpp
+++ b/gi_core/include/math/vectorized/gamma_index_single.hpp
@@ -1,0 +1,318 @@
+#pragma once
+
+#include <math/vectorized/common.hpp>
+
+namespace yagit::core::math::vectorized
+{
+	// -------- DD float32 --------
+
+	template<unsigned VectorSize, typename E0, typename E1>
+	inline simdpp::float32<VectorSize> dose_difference(
+		const simdpp::float32<VectorSize, E0>& reference_dose, const simdpp::float32<VectorSize, E1>& target_dose,
+		const vlocal_gamma_index_params<float, VectorSize>& params)
+	{
+		auto intermediate = (reference_dose - target_dose) / (reference_dose * params.percentage);
+		return intermediate * intermediate;
+	}
+
+	template<unsigned VectorSize, typename E0, typename E1>
+	inline simdpp::float32<VectorSize> dose_difference(
+		const simdpp::float32<VectorSize, E0>& reference_dose, const simdpp::float32<VectorSize, E1>& target_dose,
+		const vglobal_gamma_index_params<float, VectorSize>& params)
+	{
+		auto intermediate = (reference_dose - target_dose);
+		return (intermediate * intermediate) / params.dose_difference_squared;
+	}
+
+	// -------- DD float64 --------
+
+	template<unsigned VectorSize, typename E0, typename E1>
+	inline simdpp::float64<VectorSize> dose_difference(
+		const simdpp::float64<VectorSize, E0>& reference_dose, const simdpp::float64<VectorSize, E1>& target_dose,
+		const vlocal_gamma_index_params<double, VectorSize>& params)
+	{
+		auto intermediate = (reference_dose - target_dose) / (reference_dose * params.percentage);
+		return intermediate * intermediate;
+	}
+
+	template<unsigned VectorSize, typename E0, typename E1>
+	inline simdpp::float64<VectorSize> dose_difference(
+		const simdpp::float64<VectorSize, E0>& reference_dose, const simdpp::float64<VectorSize, E1>& target_dose,
+		const vglobal_gamma_index_params<double, VectorSize>& params)
+	{
+		auto intermediate = (reference_dose - target_dose);
+		return (intermediate * intermediate) / params.dose_difference_squared;
+	}
+
+	// -------- DTA float32 --------
+
+	template<unsigned VectorSize, typename E0, typename E1>
+	inline simdpp::float32<VectorSize> distance_to_agreement(
+		const simdpp::float32<VectorSize, E0>& reference_x,
+		const simdpp::float32<VectorSize, E1>& target_x,
+		const vlocal_gamma_index_params<float, VectorSize>& params)
+	{
+		auto intermediate_x = (target_x - reference_x);
+		return (intermediate_x * intermediate_x) / params.distance_to_agreement_squared;
+	}
+
+	template<unsigned VectorSize, typename E0, typename E1, typename E2, typename E3>
+	inline simdpp::float32<VectorSize> distance_to_agreement(
+		const simdpp::float32<VectorSize, E0>& reference_x, const simdpp::float32<VectorSize, E1>& reference_y,
+		const simdpp::float32<VectorSize, E2>& target_x, const simdpp::float32<VectorSize, E3>& target_y,
+		const vlocal_gamma_index_params<float, VectorSize>& params)
+	{
+		auto intermediate_x = (target_x - reference_x);
+		auto intermediate_y = (target_y - reference_y);
+		return (intermediate_x * intermediate_x + intermediate_y * intermediate_y) / params.distance_to_agreement_squared;
+	}
+
+	template<unsigned VectorSize, typename E0, typename E1, typename E2, typename E3, typename E4, typename E5>
+	inline simdpp::float32<VectorSize> distance_to_agreement(
+		const simdpp::float32<VectorSize, E0>& reference_x, const simdpp::float32<VectorSize, E1>& reference_y, const simdpp::float32<VectorSize, E2>& reference_z,
+		const simdpp::float32<VectorSize, E3>& target_x, const simdpp::float32<VectorSize, E4>& target_y, const simdpp::float32<VectorSize, E5>& target_z,
+		const vlocal_gamma_index_params<float, VectorSize>& params)
+	{
+		auto intermediate_x = (target_x - reference_x);
+		auto intermediate_y = (target_y - reference_y);
+		auto intermediate_z = (target_z - reference_z);
+		return (intermediate_x * intermediate_x + intermediate_y * intermediate_y + intermediate_z * intermediate_z) / params.distance_to_agreement_squared;
+	}
+
+	template<unsigned VectorSize, typename E0, typename E1>
+	inline simdpp::float32<VectorSize> distance_to_agreement(
+		const simdpp::float32<VectorSize, E0>& reference_x,
+		const simdpp::float32<VectorSize, E1>& target_x,
+		const vglobal_gamma_index_params<float, VectorSize>& params)
+	{
+		auto intermediate_x = (target_x - reference_x);
+		return (intermediate_x * intermediate_x) / params.distance_to_agreement_squared;
+	}
+
+	template<unsigned VectorSize, typename E0, typename E1, typename E2, typename E3>
+	inline simdpp::float32<VectorSize> distance_to_agreement(
+		const simdpp::float32<VectorSize, E0>& reference_x, const simdpp::float32<VectorSize, E1>& reference_y,
+		const simdpp::float32<VectorSize, E2>& target_x, const simdpp::float32<VectorSize, E3>& target_y,
+		const vglobal_gamma_index_params<float, VectorSize>& params)
+	{
+		auto intermediate_x = (target_x - reference_x);
+		auto intermediate_y = (target_y - reference_y);
+		return (intermediate_x * intermediate_x + intermediate_y * intermediate_y) / params.distance_to_agreement_squared;
+	}
+
+	template<unsigned VectorSize, typename E0, typename E1, typename E2, typename E3, typename E4, typename E5>
+	inline simdpp::float32<VectorSize> distance_to_agreement(
+		const simdpp::float32<VectorSize, E0>& reference_x, const simdpp::float32<VectorSize, E1>& reference_y, const simdpp::float32<VectorSize, E2>& reference_z,
+		const simdpp::float32<VectorSize, E3>& target_x, const simdpp::float32<VectorSize, E4>& target_y, const simdpp::float32<VectorSize, E5>& target_z,
+		const vglobal_gamma_index_params<float, VectorSize>& params)
+	{
+		auto intermediate_x = (target_x - reference_x);
+		auto intermediate_y = (target_y - reference_y);
+		auto intermediate_z = (target_z - reference_z);
+		return (intermediate_x * intermediate_x + intermediate_y * intermediate_y + intermediate_z * intermediate_z) / params.distance_to_agreement_squared;
+	}
+
+	// -------- DTA float64 --------
+
+	template<unsigned VectorSize, typename E0, typename E1>
+	inline simdpp::float64<VectorSize> distance_to_agreement(
+		const simdpp::float64<VectorSize, E0>& reference_x,
+		const simdpp::float64<VectorSize, E1>& target_x,
+		const vlocal_gamma_index_params<double, VectorSize>& params)
+	{
+		auto intermediate_x = (target_x - reference_x);
+		return (intermediate_x * intermediate_x) / params.distance_to_agreement_squared;
+	}
+
+	template<unsigned VectorSize, typename E0, typename E1, typename E2, typename E3>
+	inline simdpp::float64<VectorSize> distance_to_agreement(
+		const simdpp::float64<VectorSize, E0>& reference_x, const simdpp::float64<VectorSize, E1>& reference_y,
+		const simdpp::float64<VectorSize, E2>& target_x, const simdpp::float64<VectorSize, E3>& target_y,
+		const vlocal_gamma_index_params<double, VectorSize>& params)
+	{
+		auto intermediate_x = (target_x - reference_x);
+		auto intermediate_y = (target_y - reference_y);
+		return (intermediate_x * intermediate_x + intermediate_y * intermediate_y) / params.distance_to_agreement_squared;
+	}
+
+	template<unsigned VectorSize, typename E0, typename E1, typename E2, typename E3, typename E4, typename E5>
+	inline simdpp::float64<VectorSize> distance_to_agreement(
+		const simdpp::float64<VectorSize, E0>& reference_x, const simdpp::float64<VectorSize, E1>& reference_y, const simdpp::float64<VectorSize, E2>& reference_z,
+		const simdpp::float64<VectorSize, E3>& target_x, const simdpp::float64<VectorSize, E4>& target_y, const simdpp::float64<VectorSize, E5>& target_z,
+		const vlocal_gamma_index_params<double, VectorSize>& params)
+	{
+		auto intermediate_x = (target_x - reference_x);
+		auto intermediate_y = (target_y - reference_y);
+		auto intermediate_z = (target_z - reference_z);
+		return (intermediate_x * intermediate_x + intermediate_y * intermediate_y + intermediate_z * intermediate_z) / params.distance_to_agreement_squared;
+	}
+
+	template<unsigned VectorSize, typename E0, typename E1>
+	inline simdpp::float64<VectorSize> distance_to_agreement(
+		const simdpp::float64<VectorSize, E0>& reference_x,
+		const simdpp::float64<VectorSize, E1>& target_x,
+		const vglobal_gamma_index_params<double, VectorSize>& params)
+	{
+		auto intermediate_x = (target_x - reference_x);
+		return (intermediate_x * intermediate_x) / params.distance_to_agreement_squared;
+	}
+
+	template<unsigned VectorSize, typename E0, typename E1, typename E2, typename E3>
+	inline simdpp::float64<VectorSize> distance_to_agreement(
+		const simdpp::float64<VectorSize, E0>& reference_x, const simdpp::float64<VectorSize, E1>& reference_y,
+		const simdpp::float64<VectorSize, E2>& target_x, const simdpp::float64<VectorSize, E3>& target_y,
+		const vglobal_gamma_index_params<double, VectorSize>& params)
+	{
+		auto intermediate_x = (target_x - reference_x);
+		auto intermediate_y = (target_y - reference_y);
+		return (intermediate_x * intermediate_x + intermediate_y * intermediate_y) / params.distance_to_agreement_squared;
+	}
+
+	template<unsigned VectorSize, typename E0, typename E1, typename E2, typename E3, typename E4, typename E5>
+	inline simdpp::float64<VectorSize> distance_to_agreement(
+		const simdpp::float64<VectorSize, E0>& reference_x, const simdpp::float64<VectorSize, E1>& reference_y, const simdpp::float64<VectorSize, E2>& reference_z,
+		const simdpp::float64<VectorSize, E3>& target_x, const simdpp::float64<VectorSize, E4>& target_y, const simdpp::float64<VectorSize, E5>& target_z,
+		const vglobal_gamma_index_params<double, VectorSize>& params)
+	{
+		auto intermediate_x = (target_x - reference_x);
+		auto intermediate_y = (target_y - reference_y);
+		auto intermediate_z = (target_z - reference_z);
+		return (intermediate_x * intermediate_x + intermediate_y * intermediate_y + intermediate_z * intermediate_z) / params.distance_to_agreement_squared;
+	}
+
+	// -------- GI float32 --------
+
+	template<unsigned VectorSize, typename E0, typename E1, typename E2, typename E3>
+	inline simdpp::float32<VectorSize> gamma_index(
+		const simdpp::float32<VectorSize, E0>& reference_dose,
+		const simdpp::float32<VectorSize, E1>& target_dose,
+		const simdpp::float32<VectorSize, E2>& reference_x,
+		const simdpp::float32<VectorSize, E3>& target_x,
+		const vlocal_gamma_index_params<float, VectorSize>& params)
+	{
+		return dose_difference(reference_dose, target_dose, params) + distance_to_agreement(reference_x, target_x, params);
+	}
+
+	template<unsigned VectorSize, typename E0, typename E1, typename E2, typename E3, typename E4, typename E5>
+	inline simdpp::float32<VectorSize> gamma_index(
+		const simdpp::float32<VectorSize, E0>& reference_dose,
+		const simdpp::float32<VectorSize, E1>& target_dose,
+		const simdpp::float32<VectorSize, E2>& reference_x, const simdpp::float32<VectorSize, E3>& reference_y,
+		const simdpp::float32<VectorSize, E4>& target_x, const simdpp::float32<VectorSize, E5>& target_y,
+		const vlocal_gamma_index_params<float, VectorSize>& params)
+	{
+		return dose_difference(reference_dose, target_dose, params) + distance_to_agreement(reference_x, reference_y, target_x, target_y, params);
+	}
+
+	template<unsigned VectorSize, typename E0, typename E1, typename E2, typename E3, typename E4, typename E5, typename E6, typename E7>
+	inline simdpp::float32<VectorSize> gamma_index(
+		const simdpp::float32<VectorSize, E0>& reference_dose,
+		const simdpp::float32<VectorSize, E1>& target_dose,
+		const simdpp::float32<VectorSize, E2>& reference_x, const simdpp::float32<VectorSize, E3>& reference_y, const simdpp::float32<VectorSize, E4>& reference_z,
+		const simdpp::float32<VectorSize, E5>& target_x, const simdpp::float32<VectorSize, E6>& target_y, const simdpp::float32<VectorSize, E7>& target_z,
+		const vlocal_gamma_index_params<float, VectorSize>& params)
+	{
+		return dose_difference(reference_dose, target_dose, params) + distance_to_agreement(reference_x, reference_y, reference_z, target_x, target_y, target_z, params);
+	}
+
+	template<unsigned VectorSize, typename E0, typename E1, typename E2, typename E3>
+	inline simdpp::float32<VectorSize> gamma_index(
+		const simdpp::float32<VectorSize, E0>& reference_dose,
+		const simdpp::float32<VectorSize, E1>& target_dose,
+		const simdpp::float32<VectorSize, E2>& reference_x,
+		const simdpp::float32<VectorSize, E3>& target_x,
+		const vglobal_gamma_index_params<float, VectorSize>& params)
+	{
+		return dose_difference(reference_dose, target_dose, params) + distance_to_agreement(reference_x, target_x, params);
+	}
+
+	template<unsigned VectorSize, typename E0, typename E1, typename E2, typename E3, typename E4, typename E5>
+	inline simdpp::float32<VectorSize> gamma_index(
+		const simdpp::float32<VectorSize, E0>& reference_dose,
+		const simdpp::float32<VectorSize, E1>& target_dose,
+		const simdpp::float32<VectorSize, E2>& reference_x, const simdpp::float32<VectorSize, E3>& reference_y,
+		const simdpp::float32<VectorSize, E4>& target_x, const simdpp::float32<VectorSize, E5>& target_y,
+		const vglobal_gamma_index_params<float, VectorSize>& params)
+	{
+		return dose_difference(reference_dose, target_dose, params) + distance_to_agreement(reference_x, reference_y, target_x, target_y, params);
+	}
+
+	template<unsigned VectorSize, typename E0, typename E1, typename E2, typename E3, typename E4, typename E5, typename E6, typename E7>
+	inline simdpp::float32<VectorSize> gamma_index(
+		const simdpp::float32<VectorSize, E0>& reference_dose,
+		const simdpp::float32<VectorSize, E1>& target_dose,
+		const simdpp::float32<VectorSize, E2>& reference_x, const simdpp::float32<VectorSize, E3>& reference_y, const simdpp::float32<VectorSize, E4>& reference_z,
+		const simdpp::float32<VectorSize, E5>& target_x, const simdpp::float32<VectorSize, E6>& target_y, const simdpp::float32<VectorSize, E7>& target_z,
+		const vglobal_gamma_index_params<float, VectorSize>& params)
+	{
+		return dose_difference(reference_dose, target_dose, params) + distance_to_agreement(reference_x, reference_y, reference_z, target_x, target_y, target_z, params);
+	}
+
+	// -------- GI float64 --------
+
+	template<unsigned VectorSize, typename E0, typename E1, typename E2, typename E3>
+	inline simdpp::float64<VectorSize> gamma_index(
+		const simdpp::float64<VectorSize, E0>& reference_dose,
+		const simdpp::float64<VectorSize, E1>& target_dose,
+		const simdpp::float64<VectorSize, E2>& reference_x,
+		const simdpp::float64<VectorSize, E3>& target_x,
+		const vlocal_gamma_index_params<double, VectorSize>& params)
+	{
+		return dose_difference(reference_dose, target_dose, params) + distance_to_agreement(reference_x, target_x, params);
+	}
+
+	template<unsigned VectorSize, typename E0, typename E1, typename E2, typename E3, typename E4, typename E5>
+	inline simdpp::float64<VectorSize> gamma_index(
+		const simdpp::float64<VectorSize, E0>& reference_dose,
+		const simdpp::float64<VectorSize, E1>& target_dose,
+		const simdpp::float64<VectorSize, E2>& reference_x, const simdpp::float64<VectorSize, E3>& reference_y,
+		const simdpp::float64<VectorSize, E4>& target_x, const simdpp::float64<VectorSize, E5>& target_y,
+		const vlocal_gamma_index_params<double, VectorSize>& params)
+	{
+		return dose_difference(reference_dose, target_dose, params) + distance_to_agreement(reference_x, reference_y, target_x, target_y, params);
+	}
+
+	template<unsigned VectorSize, typename E0, typename E1, typename E2, typename E3, typename E4, typename E5, typename E6, typename E7>
+	inline simdpp::float64<VectorSize> gamma_index(
+		const simdpp::float64<VectorSize, E0>& reference_dose,
+		const simdpp::float64<VectorSize, E1>& target_dose,
+		const simdpp::float64<VectorSize, E2>& reference_x, const simdpp::float64<VectorSize, E3>& reference_y, const simdpp::float64<VectorSize, E4>& reference_z,
+		const simdpp::float64<VectorSize, E5>& target_x, const simdpp::float64<VectorSize, E6>& target_y, const simdpp::float64<VectorSize, E7>& target_z,
+		const vlocal_gamma_index_params<double, VectorSize>& params)
+	{
+		return dose_difference(reference_dose, target_dose, params) + distance_to_agreement(reference_x, reference_y, reference_z, target_x, target_y, target_z, params);
+	}
+
+	template<unsigned VectorSize, typename E0, typename E1, typename E2, typename E3>
+	inline simdpp::float64<VectorSize> gamma_index(
+		const simdpp::float64<VectorSize, E0>& reference_dose,
+		const simdpp::float64<VectorSize, E1>& target_dose,
+		const simdpp::float64<VectorSize, E2>& reference_x,
+		const simdpp::float64<VectorSize, E3>& target_x,
+		const vglobal_gamma_index_params<double, VectorSize>& params)
+	{
+		return dose_difference(reference_dose, target_dose, params) + distance_to_agreement(reference_x, target_x, params);
+	}
+
+	template<unsigned VectorSize, typename E0, typename E1, typename E2, typename E3, typename E4, typename E5>
+	inline simdpp::float64<VectorSize> gamma_index(
+		const simdpp::float64<VectorSize, E0>& reference_dose,
+		const simdpp::float64<VectorSize, E1>& target_dose,
+		const simdpp::float64<VectorSize, E2>& reference_x, const simdpp::float64<VectorSize, E3>& reference_y,
+		const simdpp::float64<VectorSize, E4>& target_x, const simdpp::float64<VectorSize, E5>& target_y,
+		const vglobal_gamma_index_params<double, VectorSize>& params)
+	{
+		return dose_difference(reference_dose, target_dose, params) + distance_to_agreement(reference_x, reference_y, target_x, target_y, params);
+	}
+
+	template<unsigned VectorSize, typename E0, typename E1, typename E2, typename E3, typename E4, typename E5, typename E6, typename E7>
+	inline simdpp::float64<VectorSize> gamma_index(
+		const simdpp::float64<VectorSize, E0>& reference_dose,
+		const simdpp::float64<VectorSize, E1>& target_dose,
+		const simdpp::float64<VectorSize, E2>& reference_x, const simdpp::float64<VectorSize, E3>& reference_y, const simdpp::float64<VectorSize, E4>& reference_z,
+		const simdpp::float64<VectorSize, E5>& target_x, const simdpp::float64<VectorSize, E6>& target_y, const simdpp::float64<VectorSize, E7>& target_z,
+		const vglobal_gamma_index_params<double, VectorSize>& params)
+	{
+		return dose_difference(reference_dose, target_dose, params) + distance_to_agreement(reference_x, reference_y, reference_z, target_x, target_y, target_z, params);
+	}
+}

--- a/gi_core/include/math/vectorized/openmp/gamma_index_range.hpp
+++ b/gi_core/include/math/vectorized/openmp/gamma_index_range.hpp
@@ -1,0 +1,153 @@
+#pragma once
+
+#include <math/vectorized/common.hpp>
+
+#include <math/basic/openmp/gamma_index_range.hpp>
+
+namespace yagit::core::math
+{
+	template<typename Type, size_t Dimensions>
+	struct parallel_unsequenced_gamma_index_implementer : public parallel_gamma_index_implementer<Type, Dimensions> {};
+
+	// -------- float32 --------
+
+	template<>
+	struct parallel_unsequenced_gamma_index_implementer<float, 1>
+	{
+		using value_type = float;
+
+		static error_code initialize_pass(view<value_type> output, view<value_type> output_end);
+		static error_code minimize_pass(
+			view<value_type> output, view<value_type> output_end,
+			const_view<value_type> reference_doses,
+			array<const_view<value_type>, 1> reference_coordinates,
+			const_view<value_type> target_doses, const_view<value_type> target_doses_end,
+			array<const_view<value_type>, 1> target_coordinates,
+			const local_gamma_index_params<value_type>& params);
+		static error_code minimize_pass(
+			view<value_type> output, view<value_type> output_end,
+			const_view<value_type> reference_doses,
+			array<const_view<value_type>, 1> reference_coordinates,
+			const_view<value_type> target_doses, const_view<value_type> target_doses_end,
+			array<const_view<value_type>, 1> target_coordinates,
+			const global_gamma_index_params<value_type>& params);
+		static error_code finalize_pass(view<value_type> output, view<value_type> output_end);
+	};
+
+	template<>
+	struct parallel_unsequenced_gamma_index_implementer<float, 2>
+	{
+		using value_type = float;
+
+		static error_code initialize_pass(view<value_type> output, view<value_type> output_end);
+		static error_code minimize_pass(
+			view<value_type> output, view<value_type> output_end,
+			const_view<value_type> reference_doses,
+			array<const_view<value_type>, 2> reference_coordinates,
+			const_view<value_type> target_doses, const_view<value_type> target_doses_end,
+			array<const_view<value_type>, 2> target_coordinates,
+			const local_gamma_index_params<value_type>& params);
+		static error_code minimize_pass(
+			view<value_type> output, view<value_type> output_end,
+			const_view<value_type> reference_doses,
+			array<const_view<value_type>, 2> reference_coordinates,
+			const_view<value_type> target_doses, const_view<value_type> target_doses_end,
+			array<const_view<value_type>, 2> target_coordinates,
+			const global_gamma_index_params<value_type>& params);
+		static error_code finalize_pass(view<value_type> output, view<value_type> output_end);
+	};
+
+	template<>
+	struct parallel_unsequenced_gamma_index_implementer<float, 3>
+	{
+		using value_type = float;
+
+		static error_code initialize_pass(view<value_type> output, view<value_type> output_end);
+		static error_code minimize_pass(
+			view<value_type> output, view<value_type> output_end,
+			const_view<value_type> reference_doses,
+			array<const_view<value_type>, 3> reference_coordinates,
+			const_view<value_type> target_doses, const_view<value_type> target_doses_end,
+			array<const_view<value_type>, 3> target_coordinates,
+			const local_gamma_index_params<value_type>& params);
+		static error_code minimize_pass(
+			view<value_type> output, view<value_type> output_end,
+			const_view<value_type> reference_doses,
+			array<const_view<value_type>, 3> reference_coordinates,
+			const_view<value_type> target_doses, const_view<value_type> target_doses_end,
+			array<const_view<value_type>, 3> target_coordinates,
+			const global_gamma_index_params<value_type>& params);
+		static error_code finalize_pass(view<value_type> output, view<value_type> output_end);
+	};
+
+	// -------- float64 --------
+
+	template<>
+	struct parallel_unsequenced_gamma_index_implementer<double, 1>
+	{
+		using value_type = double;
+
+		static error_code initialize_pass(view<value_type> output, view<value_type> output_end);
+		static error_code minimize_pass(
+			view<value_type> output, view<value_type> output_end,
+			const_view<value_type> reference_doses,
+			array<const_view<value_type>, 1> reference_coordinates,
+			const_view<value_type> target_doses, const_view<value_type> target_doses_end,
+			array<const_view<value_type>, 1> target_coordinates,
+			const local_gamma_index_params<value_type>& params);
+		static error_code minimize_pass(
+			view<value_type> output, view<value_type> output_end,
+			const_view<value_type> reference_doses,
+			array<const_view<value_type>, 1> reference_coordinates,
+			const_view<value_type> target_doses, const_view<value_type> target_doses_end,
+			array<const_view<value_type>, 1> target_coordinates,
+			const global_gamma_index_params<value_type>& params);
+		static error_code finalize_pass(view<value_type> output, view<value_type> output_end);
+	};
+
+	template<>
+	struct parallel_unsequenced_gamma_index_implementer<double, 2>
+	{
+		using value_type = double;
+
+		static error_code initialize_pass(view<value_type> output, view<value_type> output_end);
+		static error_code minimize_pass(
+			view<value_type> output, view<value_type> output_end,
+			const_view<value_type> reference_doses,
+			array<const_view<value_type>, 2> reference_coordinates,
+			const_view<value_type> target_doses, const_view<value_type> target_doses_end,
+			array<const_view<value_type>, 2> target_coordinates,
+			const local_gamma_index_params<value_type>& params);
+		static error_code minimize_pass(
+			view<value_type> output, view<value_type> output_end,
+			const_view<value_type> reference_doses,
+			array<const_view<value_type>, 2> reference_coordinates,
+			const_view<value_type> target_doses, const_view<value_type> target_doses_end,
+			array<const_view<value_type>, 2> target_coordinates,
+			const global_gamma_index_params<value_type>& params);
+		static error_code finalize_pass(view<value_type> output, view<value_type> output_end);
+	};
+
+	template<>
+	struct parallel_unsequenced_gamma_index_implementer<double, 3>
+	{
+		using value_type = double;
+
+		static error_code initialize_pass(view<value_type> output, view<value_type> output_end);
+		static error_code minimize_pass(
+			view<value_type> output, view<value_type> output_end,
+			const_view<value_type> reference_doses,
+			array<const_view<value_type>, 3> reference_coordinates,
+			const_view<value_type> target_doses, const_view<value_type> target_doses_end,
+			array<const_view<value_type>, 3> target_coordinates,
+			const local_gamma_index_params<value_type>& params);
+		static error_code minimize_pass(
+			view<value_type> output, view<value_type> output_end,
+			const_view<value_type> reference_doses,
+			array<const_view<value_type>, 3> reference_coordinates,
+			const_view<value_type> target_doses, const_view<value_type> target_doses_end,
+			array<const_view<value_type>, 3> target_coordinates,
+			const global_gamma_index_params<value_type>& params);
+		static error_code finalize_pass(view<value_type> output, view<value_type> output_end);
+	};
+}

--- a/gi_core/performance_analysis/CMakeLists.txt
+++ b/gi_core/performance_analysis/CMakeLists.txt
@@ -1,0 +1,35 @@
+# This file is part of 'yet Another Gamma Index Tool'.
+#
+# 'yet Another Gamma Index Tool' is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# 'yet Another Gamma Index Tool' is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with 'yet Another Gamma Index Tool'; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+cmake_minimum_required(VERSION 3.8)
+project(gi_core_performance_analysis)
+
+enable_testing()
+
+find_c_and_cpp_files("${CMAKE_CURRENT_SOURCE_DIR}" gi_core_performance_analysis_sources)
+
+add_executable(gi_core_performance_analysis ${gi_core_performance_analysis_sources})
+target_link_libraries(gi_core_performance_analysis PRIVATE gi_core)
+target_include_directories(gi_core_performance_analysis PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/tests)
+
+set_target_properties(gi_core_performance_analysis
+    PROPERTIES
+    CXX_STANDARD 20
+    CXX_STANDARD_REQUIRED YES
+    CXX_EXTENSIONS NO
+)
+
+set_default_output_directories(gi_core_performance_analysis)

--- a/gi_core/performance_analysis/main.cpp
+++ b/gi_core/performance_analysis/main.cpp
@@ -1,0 +1,173 @@
+#include <math/gamma_index.hpp>
+#include <random>
+#include <iostream>
+#include <image.h>
+#include <solver.h>
+
+using namespace yagit::core::math;
+using namespace yagit::core::data;
+using namespace std;
+
+void test_float()
+{
+	random_device r;
+	default_random_engine e1(r());
+	uniform_real_distribution<float> uniform_dist(0.0, 10.0f);
+
+	constexpr size_t S = 10000000;
+	constexpr float epsilon = 1e-4;
+
+	vector<float> output_seq(S, 0.0f);
+	vector<float> output_unseq(S, 0.0f);
+	vector<float> output_par(S, 0.0f);
+	vector<float> output_par_unseq(S, 0.0f);
+
+	vector<float> ref_doses(S, 0.0f);
+	vector<float> ref_x(S, 0.0f);
+	vector<float> ref_y(S, 0.0f);
+	vector<float> ref_z(S, 0.0f);
+
+	vector<float> tar_doses(S, 0.0f);
+	vector<float> tar_x(S, 0.0f);
+	vector<float> tar_y(S, 0.0f);
+	vector<float> tar_z(S, 0.0f);
+
+	auto gen = [&]() {return uniform_dist(e1); };
+
+	std::generate_n(ref_doses.data(), S, gen);
+	std::generate_n(ref_x.data(), S, gen);
+	std::generate_n(ref_y.data(), S, gen);
+	std::generate_n(ref_z.data(), S, gen);
+
+	std::generate_n(tar_doses.data(), S, gen);
+	std::generate_n(tar_x.data(), S, gen);
+	std::generate_n(tar_y.data(), S, gen);
+	std::generate_n(tar_z.data(), S, gen);
+
+	local_gamma_index_params<float> params{ 0.5f, 1.0f };
+
+	parallel_unsequenced_gamma_index_implementer<float, 3>::initialize_pass(output_par_unseq.data(), output_par_unseq.data() + S);
+	parallel_unsequenced_gamma_index_implementer<float, 3>::minimize_pass(
+		output_par_unseq.data(), output_par_unseq.data() + S,
+		ref_doses.data(),
+		array<const float*, 3>{ref_x.data(), ref_y.data(), ref_z.data()},
+		tar_doses.data(), tar_doses.data() + S,
+		array<const float*, 3>{tar_x.data(), tar_y.data(), tar_z.data()},
+		params
+	);
+	parallel_unsequenced_gamma_index_implementer<float, 3>::finalize_pass(output_par_unseq.data(), output_par_unseq.data() + S);
+}
+
+void test_double()
+{
+	random_device r;
+	default_random_engine e1(r());
+	uniform_real_distribution<double> uniform_dist(0.0, 10.0f);
+
+	constexpr size_t S = 1000000;
+	constexpr double epsilon = 1e-9;
+
+	vector<double> output_seq(S, 0.0);
+	vector<double> output_unseq(S, 0.0);
+	vector<double> output_par(S, 0.0);
+	vector<double> output_par_unseq(S, 0.0);
+
+	vector<double> ref_doses(S, 0.0);
+	vector<double> ref_x(S, 0.0);
+	vector<double> ref_y(S, 0.0);
+	vector<double> ref_z(S, 0.0);
+
+	vector<double> tar_doses(S, 0.0);
+	vector<double> tar_x(S, 0.0);
+	vector<double> tar_y(S, 0.0);
+	vector<double> tar_z(S, 0.0);
+
+	auto gen = [&]() {return uniform_dist(e1); };
+
+	std::generate_n(ref_doses.data(), S, gen);
+	std::generate_n(ref_x.data(), S, gen);
+	std::generate_n(ref_y.data(), S, gen);
+	std::generate_n(ref_z.data(), S, gen);
+
+	std::generate_n(tar_doses.data(), S, gen);
+	std::generate_n(tar_x.data(), S, gen);
+	std::generate_n(tar_y.data(), S, gen);
+	std::generate_n(tar_z.data(), S, gen);
+
+	local_gamma_index_params<double> params{ 0.5f, 1.0f };
+
+	unsequenced_gamma_index_implementer<double, 3>::initialize_pass(output_par_unseq.data(), output_par_unseq.data() + S);
+	unsequenced_gamma_index_implementer<double, 3>::minimize_pass(
+		output_par_unseq.data(), output_par_unseq.data() + S,
+		ref_doses.data(),
+		array<const double*, 3>{ref_x.data(), ref_y.data(), ref_z.data()},
+		tar_doses.data(), tar_doses.data() + S,
+		array<const double*, 3>{tar_x.data(), tar_y.data(), tar_z.data()},
+		params
+	);
+	unsequenced_gamma_index_implementer<double, 3>::finalize_pass(output_par_unseq.data(), output_par_unseq.data() + S);
+}
+
+void test_orig_sr()
+{
+	random_device r;
+	default_random_engine e1(r());
+	uniform_real_distribution<double> uniform_dist(0.0, 10.0f);
+	auto gen = [&]() {return uniform_dist(e1); };
+
+	constexpr size_t SX = 100;
+	constexpr size_t SY = 20;
+	constexpr size_t SZ = 10;
+	constexpr size_t S = SX * SY * SZ;
+	constexpr double epsilon = 1e-9;
+
+	// original format
+	vector<double> ref_start = { 0.0,0.0,0.0 };
+	vector<double> ref_spacing = { 0.5,0.2,0.3 };
+	vector<vector<vector<double>>> ref_data(SX, vector<vector<double>>(SY, vector<double>(SZ, 0.0)));
+
+	for (auto& vv : ref_data)
+		for (auto& v : vv)
+			for (auto& e : v)
+				e = gen();
+
+	Image3D img_ref = Image3D(ref_start, ref_spacing, ref_data);
+
+	vector<double> tar_start = { -0.5,0.3,0.2 };
+	vector<double> tar_spacing = { 0.4,0.1,0.4 };
+	vector<vector<vector<double>>> tar_data(SX, vector<vector<double>>(SY, vector<double>(SZ, 0.0)));
+
+	for (auto& vv : tar_data)
+		for (auto& v : vv)
+			for (auto& e : v)
+				e = gen();
+
+	Image3D img_tar = Image3D(tar_start, tar_spacing, tar_data);
+
+	SpiralNoRectangleSolver3D solver = SpiralNoRectangleSolver3D(img_ref, img_tar, 0.5f, 0.5f);
+
+	Image3D result = solver.calculateGamma();
+}
+
+
+int main()
+{
+	string test_type;
+	cout << "Select test type [float, double, orig_sr]: ";
+	cin >> test_type;
+
+	if (test_type == "float")
+	{
+		test_float();
+	}
+	else if (test_type == "double")
+	{
+		test_double();
+	}
+	else if(test_type == "orig_sr")
+	{
+		test_orig_sr();
+	}
+	
+	return 0;
+}

--- a/gi_core/src/data/allocation/fast_float_aligned_allocator.cpp
+++ b/gi_core/src/data/allocation/fast_float_aligned_allocator.cpp
@@ -1,0 +1,39 @@
+#include <data/allocation/fast_float_aligned_allocator.hpp>
+#include <data/allocation/fast_float_aligned_allocator_impl.hpp>
+
+namespace yagit::core::data
+{
+    // -------- float32 --------
+
+    float* fast_float_aligned_allocator<float>::allocate(size_type n)
+    {
+        return detail::allocate_float32(n);
+    }
+
+    allocation_result<float*> fast_float_aligned_allocator<float>::allocate_at_least(size_type n)
+    {
+        return detail::allocate_at_least_float32(n);
+    }
+
+    void fast_float_aligned_allocator<float>::deallocate(value_type* p, size_type n)
+    {
+        detail::deallocate_float32(p, n);
+    }
+
+    // -------- float64 --------
+
+    double* fast_float_aligned_allocator<double>::allocate(size_type n)
+    {
+        return detail::allocate_float64(n);
+    }
+
+    allocation_result<double*> fast_float_aligned_allocator<double>::allocate_at_least(size_type n)
+    {
+        return detail::allocate_at_least_float64(n);
+    }
+
+    void fast_float_aligned_allocator<double>::deallocate(value_type* p, size_type n)
+    {
+        detail::deallocate_float64(p, n);
+    }
+}

--- a/gi_core/src/data/allocation/fast_float_aligned_allocator_impl.hpp
+++ b/gi_core/src/data/allocation/fast_float_aligned_allocator_impl.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <common.hpp>
+
+namespace yagit::core::data::detail
+{
+    // -------- float32 --------
+
+    float* allocate_float32(size_t n);
+    allocation_result<float*> allocate_at_least_float32(size_t n);
+    void deallocate_float32(float* p, size_t n);
+
+    // -------- float64 --------
+
+    double* allocate_float64(size_t n);
+    allocation_result<double*> allocate_at_least_float64(size_t n);
+    void deallocate_float64(double* p, size_t n);
+}

--- a/gi_core/src/math/vectorized/gamma_index_range.cpp
+++ b/gi_core/src/math/vectorized/gamma_index_range.cpp
@@ -1,0 +1,285 @@
+#include <math/vectorized/gamma_index_range.hpp>
+#include <math/vectorized/gamma_index_range_impl.hpp>
+
+namespace yagit::core::math
+{
+	// -------- float32 --------
+
+	error_code unsequenced_gamma_index_implementer<float, 1>::initialize_pass(
+		view<value_type> output, view<value_type> output_end)
+	{
+		return vectorized::detail::gamma_index_initialize_pass(output, output_end);
+	}
+
+	error_code unsequenced_gamma_index_implementer<float, 1>::minimize_pass(
+		view<value_type> output, view<value_type> output_end,
+		const_view<value_type> reference_doses,
+		array<const_view<value_type>, 1> reference_coordinates,
+		const_view<value_type> target_doses, const_view<value_type> target_doses_end,
+		array<const_view<value_type>, 1> target_coordinates,
+		const local_gamma_index_params<value_type>& params)
+	{
+		return vectorized::detail::gamma_index_minimize_pass(
+			output, output_end,
+			reference_doses,
+			reference_coordinates,
+			target_doses, target_doses_end,
+			target_coordinates,
+			params);
+	}
+
+	error_code unsequenced_gamma_index_implementer<float, 1>::minimize_pass(
+		view<value_type> output, view<value_type> output_end,
+		const_view<value_type> reference_doses,
+		array<const_view<value_type>, 1> reference_coordinates,
+		const_view<value_type> target_doses, const_view<value_type> target_doses_end,
+		array<const_view<value_type>, 1> target_coordinates,
+		const global_gamma_index_params<value_type>& params)
+	{
+		return vectorized::detail::gamma_index_minimize_pass(
+			output, output_end,
+			reference_doses,
+			reference_coordinates,
+			target_doses, target_doses_end,
+			target_coordinates,
+			params);
+	}
+
+	error_code unsequenced_gamma_index_implementer<float, 1>::finalize_pass(
+		view<value_type> output, view<value_type> output_end)
+	{
+		return vectorized::detail::gamma_index_finalize_pass(output, output_end);
+	}
+
+	error_code unsequenced_gamma_index_implementer<float, 2>::initialize_pass(
+		view<value_type> output, view<value_type> output_end)
+	{
+		return vectorized::detail::gamma_index_initialize_pass(output, output_end);
+	}
+
+	error_code unsequenced_gamma_index_implementer<float, 2>::minimize_pass(
+		view<value_type> output, view<value_type> output_end,
+		const_view<value_type> reference_doses,
+		array<const_view<value_type>, 2> reference_coordinates,
+		const_view<value_type> target_doses, const_view<value_type> target_doses_end,
+		array<const_view<value_type>, 2> target_coordinates,
+		const local_gamma_index_params<value_type>& params)
+	{
+		return vectorized::detail::gamma_index_minimize_pass(
+			output, output_end,
+			reference_doses,
+			reference_coordinates,
+			target_doses, target_doses_end,
+			target_coordinates,
+			params);
+	}
+
+	error_code unsequenced_gamma_index_implementer<float, 2>::minimize_pass(
+		view<value_type> output, view<value_type> output_end,
+		const_view<value_type> reference_doses,
+		array<const_view<value_type>, 2> reference_coordinates,
+		const_view<value_type> target_doses, const_view<value_type> target_doses_end,
+		array<const_view<value_type>, 2> target_coordinates,
+		const global_gamma_index_params<value_type>& params)
+	{
+		return vectorized::detail::gamma_index_minimize_pass(
+			output, output_end,
+			reference_doses,
+			reference_coordinates,
+			target_doses, target_doses_end,
+			target_coordinates,
+			params);
+	}
+
+	error_code unsequenced_gamma_index_implementer<float, 2>::finalize_pass(
+		view<value_type> output, view<value_type> output_end)
+	{
+		return vectorized::detail::gamma_index_finalize_pass(output, output_end);
+	}
+
+	error_code unsequenced_gamma_index_implementer<float, 3>::initialize_pass(
+		view<value_type> output, view<value_type> output_end)
+	{
+		return vectorized::detail::gamma_index_initialize_pass(output, output_end);
+	}
+
+	error_code unsequenced_gamma_index_implementer<float, 3>::minimize_pass(
+		view<value_type> output, view<value_type> output_end,
+		const_view<value_type> reference_doses,
+		array<const_view<value_type>, 3> reference_coordinates,
+		const_view<value_type> target_doses, const_view<value_type> target_doses_end,
+		array<const_view<value_type>, 3> target_coordinates,
+		const local_gamma_index_params<value_type>& params)
+	{
+		return vectorized::detail::gamma_index_minimize_pass(
+			output, output_end,
+			reference_doses,
+			reference_coordinates,
+			target_doses, target_doses_end,
+			target_coordinates,
+			params);
+	}
+
+	error_code unsequenced_gamma_index_implementer<float, 3>::minimize_pass(
+		view<value_type> output, view<value_type> output_end,
+		const_view<value_type> reference_doses,
+		array<const_view<value_type>, 3> reference_coordinates,
+		const_view<value_type> target_doses, const_view<value_type> target_doses_end,
+		array<const_view<value_type>, 3> target_coordinates,
+		const global_gamma_index_params<value_type>& params)
+	{
+		return vectorized::detail::gamma_index_minimize_pass(
+			output, output_end,
+			reference_doses,
+			reference_coordinates,
+			target_doses, target_doses_end,
+			target_coordinates,
+			params);
+	}
+
+	error_code unsequenced_gamma_index_implementer<float, 3>::finalize_pass(
+		view<value_type> output, view<value_type> output_end)
+	{
+		return vectorized::detail::gamma_index_finalize_pass(output, output_end);
+	}
+
+	// -------- float64 --------
+
+	error_code unsequenced_gamma_index_implementer<double, 1>::initialize_pass(
+		view<value_type> output, view<value_type> output_end)
+	{
+		return vectorized::detail::gamma_index_initialize_pass(output, output_end);
+	}
+
+	error_code unsequenced_gamma_index_implementer<double, 1>::minimize_pass(
+		view<value_type> output, view<value_type> output_end,
+		const_view<value_type> reference_doses,
+		array<const_view<value_type>, 1> reference_coordinates,
+		const_view<value_type> target_doses, const_view<value_type> target_doses_end,
+		array<const_view<value_type>, 1> target_coordinates,
+		const local_gamma_index_params<value_type>& params)
+	{
+		return vectorized::detail::gamma_index_minimize_pass(
+			output, output_end,
+			reference_doses,
+			reference_coordinates,
+			target_doses, target_doses_end,
+			target_coordinates,
+			params);
+	}
+
+	error_code unsequenced_gamma_index_implementer<double, 1>::minimize_pass(
+		view<value_type> output, view<value_type> output_end,
+		const_view<value_type> reference_doses,
+		array<const_view<value_type>, 1> reference_coordinates,
+		const_view<value_type> target_doses, const_view<value_type> target_doses_end,
+		array<const_view<value_type>, 1> target_coordinates,
+		const global_gamma_index_params<value_type>& params)
+	{
+		return vectorized::detail::gamma_index_minimize_pass(
+			output, output_end,
+			reference_doses,
+			reference_coordinates,
+			target_doses, target_doses_end,
+			target_coordinates,
+			params);
+	}
+
+	error_code unsequenced_gamma_index_implementer<double, 1>::finalize_pass(
+		view<value_type> output, view<value_type> output_end)
+	{
+		return vectorized::detail::gamma_index_finalize_pass(output, output_end);
+	}
+
+	error_code unsequenced_gamma_index_implementer<double, 2>::initialize_pass(
+		view<value_type> output, view<value_type> output_end)
+	{
+		return vectorized::detail::gamma_index_initialize_pass(output, output_end);
+	}
+
+	error_code unsequenced_gamma_index_implementer<double, 2>::minimize_pass(
+		view<value_type> output, view<value_type> output_end,
+		const_view<value_type> reference_doses,
+		array<const_view<value_type>, 2> reference_coordinates,
+		const_view<value_type> target_doses, const_view<value_type> target_doses_end,
+		array<const_view<value_type>, 2> target_coordinates,
+		const local_gamma_index_params<value_type>& params)
+	{
+		return vectorized::detail::gamma_index_minimize_pass(
+			output, output_end,
+			reference_doses,
+			reference_coordinates,
+			target_doses, target_doses_end,
+			target_coordinates,
+			params);
+	}
+
+	error_code unsequenced_gamma_index_implementer<double, 2>::minimize_pass(
+		view<value_type> output, view<value_type> output_end,
+		const_view<value_type> reference_doses,
+		array<const_view<value_type>, 2> reference_coordinates,
+		const_view<value_type> target_doses, const_view<value_type> target_doses_end,
+		array<const_view<value_type>, 2> target_coordinates,
+		const global_gamma_index_params<value_type>& params)
+	{
+		return vectorized::detail::gamma_index_minimize_pass(
+			output, output_end,
+			reference_doses,
+			reference_coordinates,
+			target_doses, target_doses_end,
+			target_coordinates,
+			params);
+	}
+
+	error_code unsequenced_gamma_index_implementer<double, 2>::finalize_pass(
+		view<value_type> output, view<value_type> output_end)
+	{
+		return vectorized::detail::gamma_index_finalize_pass(output, output_end);
+	}
+
+	error_code unsequenced_gamma_index_implementer<double, 3>::initialize_pass(
+		view<value_type> output, view<value_type> output_end)
+	{
+		return vectorized::detail::gamma_index_initialize_pass(output, output_end);
+	}
+
+	error_code unsequenced_gamma_index_implementer<double, 3>::minimize_pass(
+		view<value_type> output, view<value_type> output_end,
+		const_view<value_type> reference_doses,
+		array<const_view<value_type>, 3> reference_coordinates,
+		const_view<value_type> target_doses, const_view<value_type> target_doses_end,
+		array<const_view<value_type>, 3> target_coordinates,
+		const local_gamma_index_params<value_type>& params)
+	{
+		return vectorized::detail::gamma_index_minimize_pass(
+			output, output_end,
+			reference_doses,
+			reference_coordinates,
+			target_doses, target_doses_end,
+			target_coordinates,
+			params);
+	}
+
+	error_code unsequenced_gamma_index_implementer<double, 3>::minimize_pass(
+		view<value_type> output, view<value_type> output_end,
+		const_view<value_type> reference_doses,
+		array<const_view<value_type>, 3> reference_coordinates,
+		const_view<value_type> target_doses, const_view<value_type> target_doses_end,
+		array<const_view<value_type>, 3> target_coordinates,
+		const global_gamma_index_params<value_type>& params)
+	{
+		return vectorized::detail::gamma_index_minimize_pass(
+			output, output_end,
+			reference_doses,
+			reference_coordinates,
+			target_doses, target_doses_end,
+			target_coordinates,
+			params);
+	}
+
+	error_code unsequenced_gamma_index_implementer<double, 3>::finalize_pass(
+		view<value_type> output, view<value_type> output_end)
+	{
+		return vectorized::detail::gamma_index_finalize_pass(output, output_end);
+	}
+}

--- a/gi_core/src/math/vectorized/gamma_index_range_impl.hpp
+++ b/gi_core/src/math/vectorized/gamma_index_range_impl.hpp
@@ -1,0 +1,218 @@
+#pragma once
+
+#include <math/vectorized/common.hpp>
+#include <math/basic/gamma_index_range_impl.hpp>
+#include <math/vectorized/gamma_index_single.hpp>
+#include <math/basic/gamma_index_single.hpp>
+
+namespace yagit::core::math::vectorized::detail
+{
+	template<bool Alignment, unsigned VectorSize, typename Type>
+	error_code gamma_index_initialize_pass(view<Type> gamma_index_output, view<Type> gamma_index_output_end)
+	{
+		vec_t<Type, VectorSize> valueV = simdpp::splat(numeric_limits<Type>::max());
+		// vectorized
+		for (; gamma_index_output_end - gamma_index_output > VectorSize; gamma_index_output += VectorSize)
+			vectorized::store<Alignment>(gamma_index_output, valueV);
+		//fallback
+		return basic::gamma_index_initialize_pass(gamma_index_output, gamma_index_output_end);
+	}
+
+	template<bool Alignment, unsigned VectorSize, typename Type, size_t Dimensions, typename ParamsType, size_t... I>
+	error_code gamma_index_minimize_pass(
+		view<Type> gamma_index_output, view<Type> gamma_index_output_end,
+		const_view<Type> reference_doses,
+		array<const_view<Type>, Dimensions> reference_coordinates,
+		const_view<Type> target_doses, const_view<Type> target_doses_end,
+		array<const_view<Type>, Dimensions> target_coordinates,
+		const ParamsType& params,
+		index_sequence<I...>)
+	{
+		// vectorized
+		{
+			auto vparams = params_vec_t<ParamsType, VectorSize>(params);
+
+			ptrdiff_t length_targetv = (target_doses_end - target_doses) / VectorSize;
+
+			for (;
+				gamma_index_output != gamma_index_output_end;
+				++gamma_index_output, ++reference_doses, ((++reference_coordinates[I]), ...))
+			{
+				if (std::isnan(*gamma_index_output) || *gamma_index_output < static_cast<Type>(1))
+					continue;
+
+				if (std::isnan(*reference_doses))
+				{
+					*gamma_index_output = *reference_doses;
+					continue;
+				}
+
+				Type gi_minimum = numeric_limits<Type>::max();
+
+				const_view<Type> t_doses = target_doses;
+				array<const_view<Type>, Dimensions> t_coordinates = target_coordinates;
+				bool skip = false;
+				// vectorized
+				{
+					vec_t<Type, VectorSize> reference_dose = simdpp::load_splat<vec_t<Type, VectorSize>>(reference_doses);
+					array<vec_t<Type, VectorSize>, Dimensions> reference_coords = { simdpp::load_splat<vec_t<Type, VectorSize>>(reference_coordinates[I])... };
+
+					vec_t<Type, VectorSize> gi_minimumv = simdpp::splat(numeric_limits<Type>::max());
+					vec_t<Type, VectorSize> one = simdpp::splat(static_cast<Type>(1));
+
+					for (ptrdiff_t count_processed_target = 0;
+						count_processed_target < length_targetv;
+						t_doses += VectorSize, ((t_coordinates[I] += VectorSize), ...), ++count_processed_target)
+					{
+						vec_t<Type, VectorSize> target_dose = load<Alignment>(t_doses);
+						auto nan_mask_output = simdpp::isnan(target_dose);
+						vec_t<Type, VectorSize> gi = vectorized::gamma_index(reference_dose, target_dose, reference_coords[I]..., ((vec_t<Type, VectorSize>)load<Alignment>(t_coordinates[I]))..., vparams);
+						auto intermediate_minimum = simdpp::min(
+							gi_minimumv,
+							gi
+						);
+
+						gi_minimumv = simdpp::blend(gi_minimumv, intermediate_minimum, nan_mask_output);
+						if (simdpp::test_bits_any(simdpp::bit_cast<vec_t<Type, VectorSize>>(gi_minimumv < one)))
+						{
+							skip = true;
+							break;
+						}
+					}
+
+					if (skip)
+						gi_minimum = std::min(gi_minimum, vectorized::find_if(gi_minimumv, [](auto v) { return v < static_cast<Type>(1); }));
+					else
+						gi_minimum = std::min(gi_minimum, simdpp::reduce_min(gi_minimumv));
+				}
+				// fallback
+				if(!skip)
+				{
+					for (;
+						t_doses != target_doses_end;
+						++t_doses, ((++t_coordinates[I]), ...))
+					{
+						if (std::isnan(*t_doses))
+							continue;
+
+						gi_minimum = std::min(
+							gi_minimum,
+							basic::gamma_index(*reference_doses, *t_doses, (*reference_coordinates[I])..., (*t_coordinates[I])..., params)
+						);
+					}
+				}
+
+				*gamma_index_output = std::min(*gamma_index_output, gi_minimum);
+			}
+		}
+		return {};
+	}
+
+	template<bool Alignment, unsigned VectorSize, typename Type>
+	error_code gamma_index_finalize_pass(view<Type> gamma_index_output, view<Type> gamma_index_output_end)
+	{
+		// vectorized
+		for (; gamma_index_output_end - gamma_index_output > VectorSize; gamma_index_output += VectorSize)
+            vectorized::store<Alignment>(gamma_index_output, simdpp::sqrt((vec_t<Type, VectorSize>)load<Alignment>(gamma_index_output)));
+		// fallback
+		return basic::gamma_index_finalize_pass(gamma_index_output, gamma_index_output_end);
+	}
+
+	// -------- float32 --------
+
+	error_code gamma_index_initialize_pass(view<float> gamma_index_output, view<float> gamma_index_output_end);
+
+	error_code gamma_index_minimize_pass(
+		view<float> gamma_index_output, view<float> gamma_index_output_end,
+		const_view<float> reference_doses,
+		array<const_view<float>, 1> reference_coordinates,
+		const_view<float> target_doses, const_view<float> target_doses_end,
+		array<const_view<float>, 1> target_coordinates,
+		const local_gamma_index_params<float>& params);
+	error_code gamma_index_minimize_pass(
+		view<float> gamma_index_output, view<float> gamma_index_output_end,
+		const_view<float> reference_doses,
+		array<const_view<float>, 2> reference_coordinates,
+		const_view<float> target_doses, const_view<float> target_doses_end,
+		array<const_view<float>, 2> target_coordinates,
+		const local_gamma_index_params<float>& params);
+	error_code gamma_index_minimize_pass(
+		view<float> gamma_index_output, view<float> gamma_index_output_end,
+		const_view<float> reference_doses,
+		array<const_view<float>, 3> reference_coordinates,
+		const_view<float> target_doses, const_view<float> target_doses_end,
+		array<const_view<float>, 3> target_coordinates,
+		const local_gamma_index_params<float>& params);
+	error_code gamma_index_minimize_pass(
+		view<float> gamma_index_output, view<float> gamma_index_output_end,
+		const_view<float> reference_doses,
+		array<const_view<float>, 1> reference_coordinates,
+		const_view<float> target_doses, const_view<float> target_doses_end,
+		array<const_view<float>, 1> target_coordinates,
+		const global_gamma_index_params<float>& params);
+	error_code gamma_index_minimize_pass(
+		view<float> gamma_index_output, view<float> gamma_index_output_end,
+		const_view<float> reference_doses,
+		array<const_view<float>, 2> reference_coordinates,
+		const_view<float> target_doses, const_view<float> target_doses_end,
+		array<const_view<float>, 2> target_coordinates,
+		const global_gamma_index_params<float>& params);
+	error_code gamma_index_minimize_pass(
+		view<float> gamma_index_output, view<float> gamma_index_output_end,
+		const_view<float> reference_doses,
+		array<const_view<float>, 3> reference_coordinates,
+		const_view<float> target_doses, const_view<float> target_doses_end,
+		array<const_view<float>, 3> target_coordinates,
+		const global_gamma_index_params<float>& params);
+
+	error_code gamma_index_finalize_pass(view<float> gamma_index_output, view<float> gamma_index_output_end);
+
+	// -------- float64 --------
+
+	error_code gamma_index_initialize_pass(view<double> gamma_index_output, view<double> gamma_index_output_end);
+
+	error_code gamma_index_minimize_pass(
+		view<double> gamma_index_output, view<double> gamma_index_output_end,
+		const_view<double> reference_doses,
+		array<const_view<double>, 1> reference_coordinates,
+		const_view<double> target_doses, const_view<double> target_doses_end,
+		array<const_view<double>, 1> target_coordinates,
+		const local_gamma_index_params<double>& params);
+	error_code gamma_index_minimize_pass(
+		view<double> gamma_index_output, view<double> gamma_index_output_end,
+		const_view<double> reference_doses,
+		array<const_view<double>, 2> reference_coordinates,
+		const_view<double> target_doses, const_view<double> target_doses_end,
+		array<const_view<double>, 2> target_coordinates,
+		const local_gamma_index_params<double>& params);
+	error_code gamma_index_minimize_pass(
+		view<double> gamma_index_output, view<double> gamma_index_output_end,
+		const_view<double> reference_doses,
+		array<const_view<double>, 3> reference_coordinates,
+		const_view<double> target_doses, const_view<double> target_doses_end,
+		array<const_view<double>, 3> target_coordinates,
+		const local_gamma_index_params<double>& params);
+	error_code gamma_index_minimize_pass(
+		view<double> gamma_index_output, view<double> gamma_index_output_end,
+		const_view<double> reference_doses,
+		array<const_view<double>, 1> reference_coordinates,
+		const_view<double> target_doses, const_view<double> target_doses_end,
+		array<const_view<double>, 1> target_coordinates,
+		const global_gamma_index_params<double>& params);
+	error_code gamma_index_minimize_pass(
+		view<double> gamma_index_output, view<double> gamma_index_output_end,
+		const_view<double> reference_doses,
+		array<const_view<double>, 2> reference_coordinates,
+		const_view<double> target_doses, const_view<double> target_doses_end,
+		array<const_view<double>, 2> target_coordinates,
+		const global_gamma_index_params<double>& params);
+	error_code gamma_index_minimize_pass(
+		view<double> gamma_index_output, view<double> gamma_index_output_end,
+		const_view<double> reference_doses,
+		array<const_view<double>, 3> reference_coordinates,
+		const_view<double> target_doses, const_view<double> target_doses_end,
+		array<const_view<double>, 3> target_coordinates,
+		const global_gamma_index_params<double>& params);
+
+	error_code gamma_index_finalize_pass(view<double> gamma_index_output, view<double> gamma_index_output_end);
+}

--- a/gi_core/src/math/vectorized/openmp/gamma_index_range.cpp
+++ b/gi_core/src/math/vectorized/openmp/gamma_index_range.cpp
@@ -1,0 +1,285 @@
+#include <math/vectorized/openmp/gamma_index_range.hpp>
+#include <math/vectorized/openmp/gamma_index_range_impl.hpp>
+
+namespace yagit::core::math
+{
+	// -------- float32 --------
+
+	error_code parallel_unsequenced_gamma_index_implementer<float, 1>::initialize_pass(
+		view<value_type> output, view<value_type> output_end)
+	{
+		return vectorized::openmp::detail::gamma_index_initialize_pass(output, output_end);
+	}
+
+	error_code parallel_unsequenced_gamma_index_implementer<float, 1>::minimize_pass(
+		view<value_type> output, view<value_type> output_end,
+		const_view<value_type> reference_doses,
+		array<const_view<value_type>, 1> reference_coordinates,
+		const_view<value_type> target_doses, const_view<value_type> target_doses_end,
+		array<const_view<value_type>, 1> target_coordinates,
+		const local_gamma_index_params<value_type>& params)
+	{
+		return vectorized::openmp::detail::gamma_index_minimize_pass(
+			output, output_end,
+			reference_doses,
+			reference_coordinates,
+			target_doses, target_doses_end,
+			target_coordinates,
+			params);
+	}
+
+	error_code parallel_unsequenced_gamma_index_implementer<float, 1>::minimize_pass(
+		view<value_type> output, view<value_type> output_end,
+		const_view<value_type> reference_doses,
+		array<const_view<value_type>, 1> reference_coordinates,
+		const_view<value_type> target_doses, const_view<value_type> target_doses_end,
+		array<const_view<value_type>, 1> target_coordinates,
+		const global_gamma_index_params<value_type>& params)
+	{
+		return vectorized::openmp::detail::gamma_index_minimize_pass(
+			output, output_end,
+			reference_doses,
+			reference_coordinates,
+			target_doses, target_doses_end,
+			target_coordinates,
+			params);
+	}
+
+	error_code parallel_unsequenced_gamma_index_implementer<float, 1>::finalize_pass(
+		view<value_type> output, view<value_type> output_end)
+	{
+		return vectorized::openmp::detail::gamma_index_finalize_pass(output, output_end);
+	}
+
+	error_code parallel_unsequenced_gamma_index_implementer<float, 2>::initialize_pass(
+		view<value_type> output, view<value_type> output_end)
+	{
+		return vectorized::openmp::detail::gamma_index_initialize_pass(output, output_end);
+	}
+
+	error_code parallel_unsequenced_gamma_index_implementer<float, 2>::minimize_pass(
+		view<value_type> output, view<value_type> output_end,
+		const_view<value_type> reference_doses,
+		array<const_view<value_type>, 2> reference_coordinates,
+		const_view<value_type> target_doses, const_view<value_type> target_doses_end,
+		array<const_view<value_type>, 2> target_coordinates,
+		const local_gamma_index_params<value_type>& params)
+	{
+		return vectorized::openmp::detail::gamma_index_minimize_pass(
+			output, output_end,
+			reference_doses,
+			reference_coordinates,
+			target_doses, target_doses_end,
+			target_coordinates,
+			params);
+	}
+
+	error_code parallel_unsequenced_gamma_index_implementer<float, 2>::minimize_pass(
+		view<value_type> output, view<value_type> output_end,
+		const_view<value_type> reference_doses,
+		array<const_view<value_type>, 2> reference_coordinates,
+		const_view<value_type> target_doses, const_view<value_type> target_doses_end,
+		array<const_view<value_type>, 2> target_coordinates,
+		const global_gamma_index_params<value_type>& params)
+	{
+		return vectorized::openmp::detail::gamma_index_minimize_pass(
+			output, output_end,
+			reference_doses,
+			reference_coordinates,
+			target_doses, target_doses_end,
+			target_coordinates,
+			params);
+	}
+
+	error_code parallel_unsequenced_gamma_index_implementer<float, 2>::finalize_pass(
+		view<value_type> output, view<value_type> output_end)
+	{
+		return vectorized::openmp::detail::gamma_index_finalize_pass(output, output_end);
+	}
+
+	error_code parallel_unsequenced_gamma_index_implementer<float, 3>::initialize_pass(
+		view<value_type> output, view<value_type> output_end)
+	{
+		return vectorized::openmp::detail::gamma_index_initialize_pass(output, output_end);
+	}
+
+	error_code parallel_unsequenced_gamma_index_implementer<float, 3>::minimize_pass(
+		view<value_type> output, view<value_type> output_end,
+		const_view<value_type> reference_doses,
+		array<const_view<value_type>, 3> reference_coordinates,
+		const_view<value_type> target_doses, const_view<value_type> target_doses_end,
+		array<const_view<value_type>, 3> target_coordinates,
+		const local_gamma_index_params<value_type>& params)
+	{
+		return vectorized::openmp::detail::gamma_index_minimize_pass(
+			output, output_end,
+			reference_doses,
+			reference_coordinates,
+			target_doses, target_doses_end,
+			target_coordinates,
+			params);
+	}
+
+	error_code parallel_unsequenced_gamma_index_implementer<float, 3>::minimize_pass(
+		view<value_type> output, view<value_type> output_end,
+		const_view<value_type> reference_doses,
+		array<const_view<value_type>, 3> reference_coordinates,
+		const_view<value_type> target_doses, const_view<value_type> target_doses_end,
+		array<const_view<value_type>, 3> target_coordinates,
+		const global_gamma_index_params<value_type>& params)
+	{
+		return vectorized::openmp::detail::gamma_index_minimize_pass(
+			output, output_end,
+			reference_doses,
+			reference_coordinates,
+			target_doses, target_doses_end,
+			target_coordinates,
+			params);
+	}
+
+	error_code parallel_unsequenced_gamma_index_implementer<float, 3>::finalize_pass(
+		view<value_type> output, view<value_type> output_end)
+	{
+		return vectorized::openmp::detail::gamma_index_finalize_pass(output, output_end);
+	}
+
+	// -------- float64 --------
+
+	error_code parallel_unsequenced_gamma_index_implementer<double, 1>::initialize_pass(
+		view<value_type> output, view<value_type> output_end)
+	{
+		return vectorized::openmp::detail::gamma_index_initialize_pass(output, output_end);
+	}
+
+	error_code parallel_unsequenced_gamma_index_implementer<double, 1>::minimize_pass(
+		view<value_type> output, view<value_type> output_end,
+		const_view<value_type> reference_doses,
+		array<const_view<value_type>, 1> reference_coordinates,
+		const_view<value_type> target_doses, const_view<value_type> target_doses_end,
+		array<const_view<value_type>, 1> target_coordinates,
+		const local_gamma_index_params<value_type>& params)
+	{
+		return vectorized::openmp::detail::gamma_index_minimize_pass(
+			output, output_end,
+			reference_doses,
+			reference_coordinates,
+			target_doses, target_doses_end,
+			target_coordinates,
+			params);
+	}
+
+	error_code parallel_unsequenced_gamma_index_implementer<double, 1>::minimize_pass(
+		view<value_type> output, view<value_type> output_end,
+		const_view<value_type> reference_doses,
+		array<const_view<value_type>, 1> reference_coordinates,
+		const_view<value_type> target_doses, const_view<value_type> target_doses_end,
+		array<const_view<value_type>, 1> target_coordinates,
+		const global_gamma_index_params<value_type>& params)
+	{
+		return vectorized::openmp::detail::gamma_index_minimize_pass(
+			output, output_end,
+			reference_doses,
+			reference_coordinates,
+			target_doses, target_doses_end,
+			target_coordinates,
+			params);
+	}
+
+	error_code parallel_unsequenced_gamma_index_implementer<double, 1>::finalize_pass(
+		view<value_type> output, view<value_type> output_end)
+	{
+		return vectorized::openmp::detail::gamma_index_finalize_pass(output, output_end);
+	}
+
+	error_code parallel_unsequenced_gamma_index_implementer<double, 2>::initialize_pass(
+		view<value_type> output, view<value_type> output_end)
+	{
+		return vectorized::openmp::detail::gamma_index_initialize_pass(output, output_end);
+	}
+
+	error_code parallel_unsequenced_gamma_index_implementer<double, 2>::minimize_pass(
+		view<value_type> output, view<value_type> output_end,
+		const_view<value_type> reference_doses,
+		array<const_view<value_type>, 2> reference_coordinates,
+		const_view<value_type> target_doses, const_view<value_type> target_doses_end,
+		array<const_view<value_type>, 2> target_coordinates,
+		const local_gamma_index_params<value_type>& params)
+	{
+		return vectorized::openmp::detail::gamma_index_minimize_pass(
+			output, output_end,
+			reference_doses,
+			reference_coordinates,
+			target_doses, target_doses_end,
+			target_coordinates,
+			params);
+	}
+
+	error_code parallel_unsequenced_gamma_index_implementer<double, 2>::minimize_pass(
+		view<value_type> output, view<value_type> output_end,
+		const_view<value_type> reference_doses,
+		array<const_view<value_type>, 2> reference_coordinates,
+		const_view<value_type> target_doses, const_view<value_type> target_doses_end,
+		array<const_view<value_type>, 2> target_coordinates,
+		const global_gamma_index_params<value_type>& params)
+	{
+		return vectorized::openmp::detail::gamma_index_minimize_pass(
+			output, output_end,
+			reference_doses,
+			reference_coordinates,
+			target_doses, target_doses_end,
+			target_coordinates,
+			params);
+	}
+
+	error_code parallel_unsequenced_gamma_index_implementer<double, 2>::finalize_pass(
+		view<value_type> output, view<value_type> output_end)
+	{
+		return vectorized::openmp::detail::gamma_index_finalize_pass(output, output_end);
+	}
+
+	error_code parallel_unsequenced_gamma_index_implementer<double, 3>::initialize_pass(
+		view<value_type> output, view<value_type> output_end)
+	{
+		return vectorized::openmp::detail::gamma_index_initialize_pass(output, output_end);
+	}
+
+	error_code parallel_unsequenced_gamma_index_implementer<double, 3>::minimize_pass(
+		view<value_type> output, view<value_type> output_end,
+		const_view<value_type> reference_doses,
+		array<const_view<value_type>, 3> reference_coordinates,
+		const_view<value_type> target_doses, const_view<value_type> target_doses_end,
+		array<const_view<value_type>, 3> target_coordinates,
+		const local_gamma_index_params<value_type>& params)
+	{
+		return vectorized::openmp::detail::gamma_index_minimize_pass(
+			output, output_end,
+			reference_doses,
+			reference_coordinates,
+			target_doses, target_doses_end,
+			target_coordinates,
+			params);
+	}
+
+	error_code parallel_unsequenced_gamma_index_implementer<double, 3>::minimize_pass(
+		view<value_type> output, view<value_type> output_end,
+		const_view<value_type> reference_doses,
+		array<const_view<value_type>, 3> reference_coordinates,
+		const_view<value_type> target_doses, const_view<value_type> target_doses_end,
+		array<const_view<value_type>, 3> target_coordinates,
+		const global_gamma_index_params<value_type>& params)
+	{
+		return vectorized::openmp::detail::gamma_index_minimize_pass(
+			output, output_end,
+			reference_doses,
+			reference_coordinates,
+			target_doses, target_doses_end,
+			target_coordinates,
+			params);
+	}
+
+	error_code parallel_unsequenced_gamma_index_implementer<double, 3>::finalize_pass(
+		view<value_type> output, view<value_type> output_end)
+	{
+		return vectorized::openmp::detail::gamma_index_finalize_pass(output, output_end);
+	}
+}

--- a/gi_core/src/math/vectorized/openmp/gamma_index_range_impl.hpp
+++ b/gi_core/src/math/vectorized/openmp/gamma_index_range_impl.hpp
@@ -1,0 +1,235 @@
+#pragma once
+
+#include <math/vectorized/common.hpp>
+#if !defined(YAGIT_OPENMP)
+#include <math/vectorized/gamma_index_range_impl.hpp>
+#endif
+#include <math/basic/openmp/gamma_index_range_impl.hpp>
+#include <math/vectorized/gamma_index_range_impl.hpp>
+#include <math/vectorized/gamma_index_single.hpp>
+#include <math/basic/gamma_index_single.hpp>
+
+namespace yagit::core::math::vectorized::openmp::detail
+{
+#if defined(YAGIT_OPENMP)
+	template<bool Alignment, unsigned VectorSize, typename Type>
+	error_code gamma_index_initialize_pass(view<Type> gamma_index_output, view<Type> gamma_index_output_end)
+	{
+		vec_t<Type, VectorSize> valueV = simdpp::splat(numeric_limits<Type>::max());
+		// vectorized
+		long length_outputv = static_cast<long>((gamma_index_output_end - gamma_index_output) / VectorSize);
+#pragma omp parallel for
+		for (long i = 0; i < length_outputv; ++i)
+            vectorized::store<Alignment>(gamma_index_output + i * VectorSize, valueV);
+		//fallback
+		return basic::openmp::gamma_index_initialize_pass(gamma_index_output + length_outputv * VectorSize, gamma_index_output_end);
+	}
+
+	template<bool Alignment, unsigned VectorSize, typename Type, size_t Dimensions, typename ParamsType, size_t... I>
+	error_code gamma_index_minimize_pass(
+		view<Type> gamma_index_output, view<Type> gamma_index_output_end,
+		const_view<Type> reference_doses,
+		array<const_view<Type>, Dimensions> reference_coordinates,
+		const_view<Type> target_doses, const_view<Type> target_doses_end,
+		array<const_view<Type>, Dimensions> target_coordinates,
+		const ParamsType& params,
+		index_sequence<I...>)
+	{
+		// vectorized
+		{
+			auto vparams = params_vec_t<ParamsType, VectorSize>(params);
+
+			long length_outputv = static_cast<long>(gamma_index_output_end - gamma_index_output);
+			ptrdiff_t length_targetv = (target_doses_end - target_doses) / VectorSize;
+
+#pragma omp parallel for
+			for (long i = 0; i < length_outputv; ++i)
+			{
+				auto gi_output = gamma_index_output + i;
+				auto ref_doses = reference_doses + i;
+				array<const_view<Type>, Dimensions> ref_coords = { (reference_coordinates[I] + i)... };
+
+				if (std::isnan(*gi_output) || *gi_output < static_cast<Type>(1))
+					continue;
+
+				if (std::isnan(*ref_doses))
+				{
+					*gi_output = *ref_doses;
+					continue;
+				}
+
+				Type gi_minimum = numeric_limits<Type>::max();
+
+				const_view<Type> t_doses = target_doses;
+				array<const_view<Type>, Dimensions> t_coordinates = target_coordinates;
+				bool skip = false;
+				// vectorized
+				{
+					vec_t<Type, VectorSize> reference_dose = simdpp::load_splat<vec_t<Type, VectorSize>>(ref_doses);
+					array<vec_t<Type, VectorSize>, Dimensions> reference_coords = { simdpp::load_splat<vec_t<Type, VectorSize>>(ref_coords[I])... };
+
+					vec_t<Type, VectorSize> gi_minimumv = simdpp::splat(numeric_limits<Type>::max());
+					vec_t<Type, VectorSize> one = simdpp::splat(static_cast<Type>(1));
+
+					for (ptrdiff_t count_processed_target = 0;
+						count_processed_target < length_targetv;
+						t_doses += VectorSize, ((t_coordinates[I] += VectorSize), ...), ++count_processed_target)
+					{
+						vec_t<Type, VectorSize> target_dose = load<Alignment>(t_doses);
+						auto nan_mask_output = simdpp::isnan(target_dose);
+						vec_t<Type, VectorSize> gi = vectorized::gamma_index(reference_dose, target_dose, reference_coords[I]..., ((vec_t<Type, VectorSize>)load<Alignment>(t_coordinates[I]))..., vparams);
+						auto intermediate_minimum = simdpp::min(
+							gi_minimumv,
+							gi
+						);
+
+						gi_minimumv = simdpp::blend(gi_minimumv, intermediate_minimum, nan_mask_output);
+						if (simdpp::test_bits_any(simdpp::bit_cast<vec_t<Type, VectorSize>>(gi_minimumv < one)))
+						{
+							skip = true;
+							break;
+						}
+					}
+
+					if (skip)
+						gi_minimum = std::min(gi_minimum, vectorized::find_if(gi_minimumv, [](auto v) { return v < static_cast<Type>(1); }));
+					else
+						gi_minimum = std::min(gi_minimum, simdpp::reduce_min(gi_minimumv));
+				}
+				// fallback
+				if (!skip)
+				{
+					for (;
+						t_doses != target_doses_end;
+						++t_doses, ((++t_coordinates[I]), ...))
+					{
+						if (std::isnan(*t_doses))
+							continue;
+
+						gi_minimum = std::min(
+							gi_minimum,
+							basic::gamma_index(*ref_doses, *t_doses, (*ref_coords[I])..., (*t_coordinates[I])..., params)
+						);
+					}
+				}
+
+				*gi_output = std::min(*gi_output, gi_minimum);
+			}
+		}
+		return {};
+	}
+
+	template<bool Alignment, unsigned VectorSize, typename Type>
+	error_code gamma_index_finalize_pass(view<Type> gamma_index_output, view<Type> gamma_index_output_end)
+	{
+		// vectorized
+		long length_outputv = static_cast<long>((gamma_index_output_end - gamma_index_output) / VectorSize);
+#pragma omp parallel for
+		for (long i = 0; i < length_outputv; ++i)
+            vectorized::store<Alignment>(gamma_index_output + i * VectorSize, simdpp::sqrt((vec_t<Type, VectorSize>)load<Alignment>(gamma_index_output + i * VectorSize)));
+		// fallback
+		return basic::openmp::gamma_index_finalize_pass(gamma_index_output + length_outputv * VectorSize, gamma_index_output_end);
+	}
+#else
+	using vectorized::detail::gamma_index_initialize_pass;
+	using vectorized::detail::gamma_index_minimize_pass;
+	using vectorized::detail::gamma_index_finalize_pass;
+#endif
+	// -------- float32 --------
+
+	error_code gamma_index_initialize_pass(view<float> gamma_index_output, view<float> gamma_index_output_end);
+	
+	error_code gamma_index_minimize_pass(
+		view<float> gamma_index_output, view<float> gamma_index_output_end,
+		const_view<float> reference_doses,
+		array<const_view<float>, 1> reference_coordinates,
+		const_view<float> target_doses, const_view<float> target_doses_end,
+		array<const_view<float>, 1> target_coordinates,
+		const local_gamma_index_params<float>& params);
+	error_code gamma_index_minimize_pass(
+		view<float> gamma_index_output, view<float> gamma_index_output_end,
+		const_view<float> reference_doses,
+		array<const_view<float>, 2> reference_coordinates,
+		const_view<float> target_doses, const_view<float> target_doses_end,
+		array<const_view<float>, 2> target_coordinates,
+		const local_gamma_index_params<float>& params);
+	error_code gamma_index_minimize_pass(
+		view<float> gamma_index_output, view<float> gamma_index_output_end,
+		const_view<float> reference_doses,
+		array<const_view<float>, 3> reference_coordinates,
+		const_view<float> target_doses, const_view<float> target_doses_end,
+		array<const_view<float>, 3> target_coordinates,
+		const local_gamma_index_params<float>& params);
+	error_code gamma_index_minimize_pass(
+		view<float> gamma_index_output, view<float> gamma_index_output_end,
+		const_view<float> reference_doses,
+		array<const_view<float>, 1> reference_coordinates,
+		const_view<float> target_doses, const_view<float> target_doses_end,
+		array<const_view<float>, 1> target_coordinates,
+		const global_gamma_index_params<float>& params);
+	error_code gamma_index_minimize_pass(
+		view<float> gamma_index_output, view<float> gamma_index_output_end,
+		const_view<float> reference_doses,
+		array<const_view<float>, 2> reference_coordinates,
+		const_view<float> target_doses, const_view<float> target_doses_end,
+		array<const_view<float>, 2> target_coordinates,
+		const global_gamma_index_params<float>& params);
+	error_code gamma_index_minimize_pass(
+		view<float> gamma_index_output, view<float> gamma_index_output_end,
+		const_view<float> reference_doses,
+		array<const_view<float>, 3> reference_coordinates,
+		const_view<float> target_doses, const_view<float> target_doses_end,
+		array<const_view<float>, 3> target_coordinates,
+		const global_gamma_index_params<float>& params);
+
+	error_code gamma_index_finalize_pass(view<float> gamma_index_output, view<float> gamma_index_output_end);
+
+	// -------- float64 --------
+
+	error_code gamma_index_initialize_pass(view<double> gamma_index_output, view<double> gamma_index_output_end);
+
+	error_code gamma_index_minimize_pass(
+		view<double> gamma_index_output, view<double> gamma_index_output_end,
+		const_view<double> reference_doses,
+		array<const_view<double>, 1> reference_coordinates,
+		const_view<double> target_doses, const_view<double> target_doses_end,
+		array<const_view<double>, 1> target_coordinates,
+		const local_gamma_index_params<double>& params);
+	error_code gamma_index_minimize_pass(
+		view<double> gamma_index_output, view<double> gamma_index_output_end,
+		const_view<double> reference_doses,
+		array<const_view<double>, 2> reference_coordinates,
+		const_view<double> target_doses, const_view<double> target_doses_end,
+		array<const_view<double>, 2> target_coordinates,
+		const local_gamma_index_params<double>& params);
+	error_code gamma_index_minimize_pass(
+		view<double> gamma_index_output, view<double> gamma_index_output_end,
+		const_view<double> reference_doses,
+		array<const_view<double>, 3> reference_coordinates,
+		const_view<double> target_doses, const_view<double> target_doses_end,
+		array<const_view<double>, 3> target_coordinates,
+		const local_gamma_index_params<double>& params);
+	error_code gamma_index_minimize_pass(
+		view<double> gamma_index_output, view<double> gamma_index_output_end,
+		const_view<double> reference_doses,
+		array<const_view<double>, 1> reference_coordinates,
+		const_view<double> target_doses, const_view<double> target_doses_end,
+		array<const_view<double>, 1> target_coordinates,
+		const global_gamma_index_params<double>& params);
+	error_code gamma_index_minimize_pass(
+		view<double> gamma_index_output, view<double> gamma_index_output_end,
+		const_view<double> reference_doses,
+		array<const_view<double>, 2> reference_coordinates,
+		const_view<double> target_doses, const_view<double> target_doses_end,
+		array<const_view<double>, 2> target_coordinates,
+		const global_gamma_index_params<double>& params);
+	error_code gamma_index_minimize_pass(
+		view<double> gamma_index_output, view<double> gamma_index_output_end,
+		const_view<double> reference_doses,
+		array<const_view<double>, 3> reference_coordinates,
+		const_view<double> target_doses, const_view<double> target_doses_end,
+		array<const_view<double>, 3> target_coordinates,
+		const global_gamma_index_params<double>& params);
+
+	error_code gamma_index_finalize_pass(view<double> gamma_index_output, view<double> gamma_index_output_end);
+}

--- a/gi_core/tests/CMakeLists.txt
+++ b/gi_core/tests/CMakeLists.txt
@@ -1,0 +1,37 @@
+# This file is part of 'yet Another Gamma Index Tool'.
+#
+# 'yet Another Gamma Index Tool' is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# 'yet Another Gamma Index Tool' is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with 'yet Another Gamma Index Tool'; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+cmake_minimum_required(VERSION 3.8)
+project(gi_core_tests)
+
+enable_testing()
+
+find_c_and_cpp_files("${CMAKE_CURRENT_SOURCE_DIR}" gi_core_tests_sources)
+
+add_executable(gi_core_tests ${gi_core_tests_sources})
+target_link_libraries(gi_core_tests PRIVATE gi_core ${Boost_LIBRARIES})
+target_include_directories(gi_core_tests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/tests ${Boost_INCLUDE_DIRS})
+
+set_target_properties(gi_core_tests
+    PROPERTIES
+    CXX_STANDARD 20
+    CXX_STANDARD_REQUIRED YES
+    CXX_EXTENSIONS NO
+)
+
+set_default_output_directories(gi_core_tests)
+
+add_test(NAME gi_core_tests COMMAND gi_core_tests)

--- a/gi_core/tests/math_gi_policies_tests.cpp
+++ b/gi_core/tests/math_gi_policies_tests.cpp
@@ -1,0 +1,1350 @@
+#include <math/gamma_index.hpp>
+#include <image.h>
+#include <solver.h>
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE  math_tests
+#include <boost/test/unit_test.hpp>
+
+#include <random>
+#include <chrono>
+
+using namespace yagit::core::math;
+using namespace yagit::core::data;
+using namespace std;
+using namespace std::chrono;
+
+BOOST_AUTO_TEST_CASE(policies_relative_correctness_float)
+{
+	BOOST_TEST_MESSAGE("------------ policies_relative_correctness_float ------------");
+
+	random_device r;
+	default_random_engine e1(r());
+	uniform_real_distribution<float> uniform_dist(0.0, 10.0f);
+
+	constexpr size_t S = 1000;
+	constexpr float epsilon = 1e-4;
+
+	vector<float> output_seq(S, 0.0f);
+	vector<float> output_unseq(S, 0.0f);
+	vector<float> output_par(S, 0.0f);
+	vector<float> output_par_unseq(S, 0.0f);
+
+	vector<float> ref_doses(S, 0.0f);
+	vector<float> ref_x(S, 0.0f);
+	vector<float> ref_y(S, 0.0f);
+	vector<float> ref_z(S, 0.0f);
+
+	vector<float> tar_doses(S, 0.0f);
+	vector<float> tar_x(S, 0.0f);
+	vector<float> tar_y(S, 0.0f);
+	vector<float> tar_z(S, 0.0f);
+
+	auto gen = [&]() {return uniform_dist(e1); };
+
+	std::generate_n(ref_doses.data(), S, gen);
+	std::generate_n(ref_x.data(), S, gen);
+	std::generate_n(ref_y.data(), S, gen);
+	std::generate_n(ref_z.data(), S, gen);
+
+	std::generate_n(tar_doses.data(), S, gen);
+	std::generate_n(tar_x.data(), S, gen);
+	std::generate_n(tar_y.data(), S, gen);
+	std::generate_n(tar_z.data(), S, gen);
+
+	BOOST_TEST_MESSAGE("-------- local --------");
+	{
+		local_gamma_index_params<float> params{ 0.5f, 12.0f };
+		BOOST_TEST_MESSAGE("---- 1D ----");
+		// sequenced
+		{
+			auto start = high_resolution_clock::now();
+			sequenced_gamma_index_implementer<float, 1>::initialize_pass(output_seq.data(), output_seq.data() + S);
+			sequenced_gamma_index_implementer<float, 1>::minimize_pass(
+				output_seq.data(), output_seq.data() + S,
+				ref_doses.data(),
+				array<const float*, 1>{ref_x.data()},
+				tar_doses.data(), tar_doses.data() + S,
+				array<const float*, 1>{tar_x.data()},
+				params
+			);
+			sequenced_gamma_index_implementer<float, 1>::finalize_pass(output_seq.data(), output_seq.data() + S);
+			auto end = high_resolution_clock::now();
+			BOOST_TEST_MESSAGE("sequenced took: " << duration_cast<nanoseconds>(end - start).count() / 1e9 << 's');
+		}
+		// unsequenced
+		{
+			auto start = high_resolution_clock::now();
+			unsequenced_gamma_index_implementer<float, 1>::initialize_pass(output_unseq.data(), output_unseq.data() + S);
+			unsequenced_gamma_index_implementer<float, 1>::minimize_pass(
+				output_unseq.data(), output_unseq.data() + S,
+				ref_doses.data(),
+				array<const float*, 1>{ref_x.data()},
+				tar_doses.data(), tar_doses.data() + S,
+				array<const float*, 1>{tar_x.data()},
+				params
+			);
+			unsequenced_gamma_index_implementer<float, 1>::finalize_pass(output_unseq.data(), output_unseq.data() + S);
+			auto end = high_resolution_clock::now();
+			BOOST_TEST_MESSAGE("unsequenced took: " << duration_cast<nanoseconds>(end - start).count() / 1e9 << 's');
+		}
+		// parallel
+		{
+			auto start = high_resolution_clock::now();
+			parallel_gamma_index_implementer<float, 1>::initialize_pass(output_par.data(), output_par.data() + S);
+			parallel_gamma_index_implementer<float, 1>::minimize_pass(
+				output_par.data(), output_par.data() + S,
+				ref_doses.data(),
+				array<const float*, 1>{ref_x.data()},
+				tar_doses.data(), tar_doses.data() + S,
+				array<const float*, 1>{tar_x.data()},
+				params
+			);
+			parallel_gamma_index_implementer<float, 1>::finalize_pass(output_par.data(), output_par.data() + S);
+			auto end = high_resolution_clock::now();
+			BOOST_TEST_MESSAGE("parallel took: " << duration_cast<nanoseconds>(end - start).count() / 1e9 << 's');
+		}
+		// parallel unsequenced
+		{
+			auto start = high_resolution_clock::now();
+			parallel_unsequenced_gamma_index_implementer<float, 1>::initialize_pass(output_par_unseq.data(), output_par_unseq.data() + S);
+			parallel_unsequenced_gamma_index_implementer<float, 1>::minimize_pass(
+				output_par_unseq.data(), output_par_unseq.data() + S,
+				ref_doses.data(),
+				array<const float*, 1>{ref_x.data()},
+				tar_doses.data(), tar_doses.data() + S,
+				array<const float*, 1>{tar_x.data()},
+				params
+			);
+			parallel_unsequenced_gamma_index_implementer<float, 1>::finalize_pass(output_par_unseq.data(), output_par_unseq.data() + S);
+			auto end = high_resolution_clock::now();
+			BOOST_TEST_MESSAGE("parallel unsequenced took: " << duration_cast<nanoseconds>(end - start).count() / 1e9 << 's');
+		}
+		// compare
+		{
+			auto comp = [](auto a, auto b) {return std::abs(a - b) < epsilon; };
+			auto unseq_equal_to_seq = equal(execution::par_unseq, output_seq.data(), output_seq.data() + S, output_unseq.data(), output_unseq.data() + S, comp);
+			auto par_equal_to_seq = equal(execution::par_unseq, output_seq.data(), output_seq.data() + S, output_par.data(), output_par.data() + S, comp);
+			auto par_unseq_equal_to_seq = equal(execution::par_unseq, output_seq.data(), output_seq.data() + S, output_par_unseq.data(), output_par_unseq.data() + S, comp);
+
+			BOOST_CHECK(unseq_equal_to_seq);
+			BOOST_CHECK(par_equal_to_seq);
+			BOOST_CHECK(par_unseq_equal_to_seq);
+		}
+		BOOST_TEST_MESSAGE("---- 2D ----");
+		// sequenced
+		{
+			auto start = high_resolution_clock::now();
+			sequenced_gamma_index_implementer<float, 2>::initialize_pass(output_seq.data(), output_seq.data() + S);
+			sequenced_gamma_index_implementer<float, 2>::minimize_pass(
+				output_seq.data(), output_seq.data() + S,
+				ref_doses.data(),
+				array<const float*, 2>{ref_x.data(), ref_y.data()},
+				tar_doses.data(), tar_doses.data() + S,
+				array<const float*, 2>{tar_x.data(), tar_y.data()},
+				params
+			);
+			sequenced_gamma_index_implementer<float, 2>::finalize_pass(output_seq.data(), output_seq.data() + S);
+			auto end = high_resolution_clock::now();
+			BOOST_TEST_MESSAGE("sequenced took: " << duration_cast<nanoseconds>(end - start).count() / 1e9 << 's');
+		}
+		// unsequenced
+		{
+			auto start = high_resolution_clock::now();
+			unsequenced_gamma_index_implementer<float, 2>::initialize_pass(output_unseq.data(), output_unseq.data() + S);
+			unsequenced_gamma_index_implementer<float, 2>::minimize_pass(
+				output_unseq.data(), output_unseq.data() + S,
+				ref_doses.data(),
+				array<const float*, 2>{ref_x.data(), ref_y.data()},
+				tar_doses.data(), tar_doses.data() + S,
+				array<const float*, 2>{tar_x.data(), tar_y.data()},
+				params
+			);
+			unsequenced_gamma_index_implementer<float, 2>::finalize_pass(output_unseq.data(), output_unseq.data() + S);
+			auto end = high_resolution_clock::now();
+			BOOST_TEST_MESSAGE("unsequenced took: " << duration_cast<nanoseconds>(end - start).count() / 1e9 << 's');
+		}
+		// parallel
+		{
+			auto start = high_resolution_clock::now();
+			parallel_gamma_index_implementer<float, 2>::initialize_pass(output_par.data(), output_par.data() + S);
+			parallel_gamma_index_implementer<float, 2>::minimize_pass(
+				output_par.data(), output_par.data() + S,
+				ref_doses.data(),
+				array<const float*, 2>{ref_x.data(), ref_y.data()},
+				tar_doses.data(), tar_doses.data() + S,
+				array<const float*, 2>{tar_x.data(), tar_y.data()},
+				params
+			);
+			parallel_gamma_index_implementer<float, 2>::finalize_pass(output_par.data(), output_par.data() + S);
+			auto end = high_resolution_clock::now();
+			BOOST_TEST_MESSAGE("parallel took: " << duration_cast<nanoseconds>(end - start).count() / 1e9 << 's');
+		}
+		// parallel unsequenced
+		{
+			auto start = high_resolution_clock::now();
+			parallel_unsequenced_gamma_index_implementer<float, 2>::initialize_pass(output_par_unseq.data(), output_par_unseq.data() + S);
+			parallel_unsequenced_gamma_index_implementer<float, 2>::minimize_pass(
+				output_par_unseq.data(), output_par_unseq.data() + S,
+				ref_doses.data(),
+				array<const float*, 2>{ref_x.data(), ref_y.data()},
+				tar_doses.data(), tar_doses.data() + S,
+				array<const float*, 2>{tar_x.data(), tar_y.data()},
+				params
+			);
+			parallel_unsequenced_gamma_index_implementer<float, 2>::finalize_pass(output_par_unseq.data(), output_par_unseq.data() + S);
+			auto end = high_resolution_clock::now();
+			BOOST_TEST_MESSAGE("parallel unsequenced took: " << duration_cast<nanoseconds>(end - start).count() / 1e9 << 's');
+		}
+		// compare
+		{
+			auto comp = [](auto a, auto b) {return std::abs(a - b) < epsilon; };
+			auto unseq_equal_to_seq = equal(execution::par_unseq, output_seq.data(), output_seq.data() + S, output_unseq.data(), output_unseq.data() + S, comp);
+			auto par_equal_to_seq = equal(execution::par_unseq, output_seq.data(), output_seq.data() + S, output_par.data(), output_par.data() + S, comp);
+			auto par_unseq_equal_to_seq = equal(execution::par_unseq, output_seq.data(), output_seq.data() + S, output_par_unseq.data(), output_par_unseq.data() + S, comp);
+
+			BOOST_CHECK(unseq_equal_to_seq);
+			BOOST_CHECK(par_equal_to_seq);
+			BOOST_CHECK(par_unseq_equal_to_seq);
+		}
+		BOOST_TEST_MESSAGE("---- 3D ----");
+		// sequenced
+		{
+			auto start = high_resolution_clock::now();
+			sequenced_gamma_index_implementer<float, 3>::initialize_pass(output_seq.data(), output_seq.data() + S);
+			sequenced_gamma_index_implementer<float, 3>::minimize_pass(
+				output_seq.data(), output_seq.data() + S,
+				ref_doses.data(),
+				array<const float*, 3>{ref_x.data(), ref_y.data(), ref_z.data()},
+				tar_doses.data(), tar_doses.data() + S,
+				array<const float*, 3>{tar_x.data(), tar_y.data(), tar_z.data()},
+				params
+			);
+			sequenced_gamma_index_implementer<float, 3>::finalize_pass(output_seq.data(), output_seq.data() + S);
+			auto end = high_resolution_clock::now();
+			BOOST_TEST_MESSAGE("sequenced took: " << duration_cast<nanoseconds>(end - start).count() / 1e9 << 's');
+		}
+		// unsequenced
+		{
+			auto start = high_resolution_clock::now();
+			unsequenced_gamma_index_implementer<float, 3>::initialize_pass(output_unseq.data(), output_unseq.data() + S);
+			unsequenced_gamma_index_implementer<float, 3>::minimize_pass(
+				output_unseq.data(), output_unseq.data() + S,
+				ref_doses.data(),
+				array<const float*, 3>{ref_x.data(), ref_y.data(), ref_z.data()},
+				tar_doses.data(), tar_doses.data() + S,
+				array<const float*, 3>{tar_x.data(), tar_y.data(), tar_z.data()},
+				params
+			);
+			unsequenced_gamma_index_implementer<float, 3>::finalize_pass(output_unseq.data(), output_unseq.data() + S);
+			auto end = high_resolution_clock::now();
+			BOOST_TEST_MESSAGE("unsequenced took: " << duration_cast<nanoseconds>(end - start).count() / 1e9 << 's');
+		}
+		// parallel
+		{
+			auto start = high_resolution_clock::now();
+			parallel_gamma_index_implementer<float, 3>::initialize_pass(output_par.data(), output_par.data() + S);
+			parallel_gamma_index_implementer<float, 3>::minimize_pass(
+				output_par.data(), output_par.data() + S,
+				ref_doses.data(),
+				array<const float*, 3>{ref_x.data(), ref_y.data(), ref_z.data()},
+				tar_doses.data(), tar_doses.data() + S,
+				array<const float*, 3>{tar_x.data(), tar_y.data(), tar_z.data()},
+				params
+			);
+			parallel_gamma_index_implementer<float, 3>::finalize_pass(output_par.data(), output_par.data() + S);
+			auto end = high_resolution_clock::now();
+			BOOST_TEST_MESSAGE("parallel took: " << duration_cast<nanoseconds>(end - start).count() / 1e9 << 's');
+		}
+		// parallel unsequenced
+		{
+			auto start = high_resolution_clock::now();
+			parallel_unsequenced_gamma_index_implementer<float, 3>::initialize_pass(output_par_unseq.data(), output_par_unseq.data() + S);
+			parallel_unsequenced_gamma_index_implementer<float, 3>::minimize_pass(
+				output_par_unseq.data(), output_par_unseq.data() + S,
+				ref_doses.data(),
+				array<const float*, 3>{ref_x.data(), ref_y.data(), ref_z.data()},
+				tar_doses.data(), tar_doses.data() + S,
+				array<const float*, 3>{tar_x.data(), tar_y.data(), tar_z.data()},
+				params
+			);
+			parallel_unsequenced_gamma_index_implementer<float, 3>::finalize_pass(output_par_unseq.data(), output_par_unseq.data() + S);
+			auto end = high_resolution_clock::now();
+			BOOST_TEST_MESSAGE("parallel unsequenced took: " << duration_cast<nanoseconds>(end - start).count() / 1e9 << 's');
+		}
+		// compare
+		{
+			auto comp = [](auto a, auto b) {return std::abs(a - b) < epsilon; };
+			auto unseq_equal_to_seq = equal(execution::par_unseq, output_seq.data(), output_seq.data() + S, output_unseq.data(), output_unseq.data() + S, comp);
+			auto par_equal_to_seq = equal(execution::par_unseq, output_seq.data(), output_seq.data() + S, output_par.data(), output_par.data() + S, comp);
+			auto par_unseq_equal_to_seq = equal(execution::par_unseq, output_seq.data(), output_seq.data() + S, output_par_unseq.data(), output_par_unseq.data() + S, comp);
+
+			BOOST_CHECK(unseq_equal_to_seq);
+			BOOST_CHECK(par_equal_to_seq);
+			BOOST_CHECK(par_unseq_equal_to_seq);
+		}
+	}
+
+	BOOST_TEST_MESSAGE("-------- global --------");
+	{
+		global_gamma_index_params<float> params{ 0.5f, 12.0f };
+		BOOST_TEST_MESSAGE("---- 1D ----");
+		// sequenced
+		{
+			auto start = high_resolution_clock::now();
+			sequenced_gamma_index_implementer<float, 1>::initialize_pass(output_seq.data(), output_seq.data() + S);
+			sequenced_gamma_index_implementer<float, 1>::minimize_pass(
+				output_seq.data(), output_seq.data() + S,
+				ref_doses.data(),
+				array<const float*, 1>{ref_x.data()},
+				tar_doses.data(), tar_doses.data() + S,
+				array<const float*, 1>{tar_x.data()},
+				params
+			);
+			sequenced_gamma_index_implementer<float, 1>::finalize_pass(output_seq.data(), output_seq.data() + S);
+			auto end = high_resolution_clock::now();
+			BOOST_TEST_MESSAGE("sequenced took: " << duration_cast<nanoseconds>(end - start).count() / 1e9 << 's');
+		}
+		// unsequenced
+		{
+			auto start = high_resolution_clock::now();
+			unsequenced_gamma_index_implementer<float, 1>::initialize_pass(output_unseq.data(), output_unseq.data() + S);
+			unsequenced_gamma_index_implementer<float, 1>::minimize_pass(
+				output_unseq.data(), output_unseq.data() + S,
+				ref_doses.data(),
+				array<const float*, 1>{ref_x.data()},
+				tar_doses.data(), tar_doses.data() + S,
+				array<const float*, 1>{tar_x.data()},
+				params
+			);
+			unsequenced_gamma_index_implementer<float, 1>::finalize_pass(output_unseq.data(), output_unseq.data() + S);
+			auto end = high_resolution_clock::now();
+			BOOST_TEST_MESSAGE("unsequenced took: " << duration_cast<nanoseconds>(end - start).count() / 1e9 << 's');
+		}
+		// parallel
+		{
+			auto start = high_resolution_clock::now();
+			parallel_gamma_index_implementer<float, 1>::initialize_pass(output_par.data(), output_par.data() + S);
+			parallel_gamma_index_implementer<float, 1>::minimize_pass(
+				output_par.data(), output_par.data() + S,
+				ref_doses.data(),
+				array<const float*, 1>{ref_x.data()},
+				tar_doses.data(), tar_doses.data() + S,
+				array<const float*, 1>{tar_x.data()},
+				params
+			);
+			parallel_gamma_index_implementer<float, 1>::finalize_pass(output_par.data(), output_par.data() + S);
+			auto end = high_resolution_clock::now();
+			BOOST_TEST_MESSAGE("parallel took: " << duration_cast<nanoseconds>(end - start).count() / 1e9 << 's');
+		}
+		// parallel unsequenced
+		{
+			auto start = high_resolution_clock::now();
+			parallel_unsequenced_gamma_index_implementer<float, 1>::initialize_pass(output_par_unseq.data(), output_par_unseq.data() + S);
+			parallel_unsequenced_gamma_index_implementer<float, 1>::minimize_pass(
+				output_par_unseq.data(), output_par_unseq.data() + S,
+				ref_doses.data(),
+				array<const float*, 1>{ref_x.data()},
+				tar_doses.data(), tar_doses.data() + S,
+				array<const float*, 1>{tar_x.data()},
+				params
+			);
+			parallel_unsequenced_gamma_index_implementer<float, 1>::finalize_pass(output_par_unseq.data(), output_par_unseq.data() + S);
+			auto end = high_resolution_clock::now();
+			BOOST_TEST_MESSAGE("parallel unsequenced took: " << duration_cast<nanoseconds>(end - start).count() / 1e9 << 's');
+		}
+		// compare
+		{
+			auto comp = [](auto a, auto b) {return std::abs(a - b) < epsilon; };
+			auto unseq_equal_to_seq = equal(execution::par_unseq, output_seq.data(), output_seq.data() + S, output_unseq.data(), output_unseq.data() + S, comp);
+			auto par_equal_to_seq = equal(execution::par_unseq, output_seq.data(), output_seq.data() + S, output_par.data(), output_par.data() + S, comp);
+			auto par_unseq_equal_to_seq = equal(execution::par_unseq, output_seq.data(), output_seq.data() + S, output_par_unseq.data(), output_par_unseq.data() + S, comp);
+
+			BOOST_CHECK(unseq_equal_to_seq);
+			BOOST_CHECK(par_equal_to_seq);
+			BOOST_CHECK(par_unseq_equal_to_seq);
+		}
+		BOOST_TEST_MESSAGE("---- 2D ----");
+		// sequenced
+		{
+			auto start = high_resolution_clock::now();
+			sequenced_gamma_index_implementer<float, 2>::initialize_pass(output_seq.data(), output_seq.data() + S);
+			sequenced_gamma_index_implementer<float, 2>::minimize_pass(
+				output_seq.data(), output_seq.data() + S,
+				ref_doses.data(),
+				array<const float*, 2>{ref_x.data(), ref_y.data()},
+				tar_doses.data(), tar_doses.data() + S,
+				array<const float*, 2>{tar_x.data(), tar_y.data()},
+				params
+			);
+			sequenced_gamma_index_implementer<float, 2>::finalize_pass(output_seq.data(), output_seq.data() + S);
+			auto end = high_resolution_clock::now();
+			BOOST_TEST_MESSAGE("sequenced took: " << duration_cast<nanoseconds>(end - start).count() / 1e9 << 's');
+		}
+		// unsequenced
+		{
+			auto start = high_resolution_clock::now();
+			unsequenced_gamma_index_implementer<float, 2>::initialize_pass(output_unseq.data(), output_unseq.data() + S);
+			unsequenced_gamma_index_implementer<float, 2>::minimize_pass(
+				output_unseq.data(), output_unseq.data() + S,
+				ref_doses.data(),
+				array<const float*, 2>{ref_x.data(), ref_y.data()},
+				tar_doses.data(), tar_doses.data() + S,
+				array<const float*, 2>{tar_x.data(), tar_y.data()},
+				params
+			);
+			unsequenced_gamma_index_implementer<float, 2>::finalize_pass(output_unseq.data(), output_unseq.data() + S);
+			auto end = high_resolution_clock::now();
+			BOOST_TEST_MESSAGE("unsequenced took: " << duration_cast<nanoseconds>(end - start).count() / 1e9 << 's');
+		}
+		// parallel
+		{
+			auto start = high_resolution_clock::now();
+			parallel_gamma_index_implementer<float, 2>::initialize_pass(output_par.data(), output_par.data() + S);
+			parallel_gamma_index_implementer<float, 2>::minimize_pass(
+				output_par.data(), output_par.data() + S,
+				ref_doses.data(),
+				array<const float*, 2>{ref_x.data(), ref_y.data()},
+				tar_doses.data(), tar_doses.data() + S,
+				array<const float*, 2>{tar_x.data(), tar_y.data()},
+				params
+			);
+			parallel_gamma_index_implementer<float, 2>::finalize_pass(output_par.data(), output_par.data() + S);
+			auto end = high_resolution_clock::now();
+			BOOST_TEST_MESSAGE("parallel took: " << duration_cast<nanoseconds>(end - start).count() / 1e9 << 's');
+		}
+		// parallel unsequenced
+		{
+			auto start = high_resolution_clock::now();
+			parallel_unsequenced_gamma_index_implementer<float, 2>::initialize_pass(output_par_unseq.data(), output_par_unseq.data() + S);
+			parallel_unsequenced_gamma_index_implementer<float, 2>::minimize_pass(
+				output_par_unseq.data(), output_par_unseq.data() + S,
+				ref_doses.data(),
+				array<const float*, 2>{ref_x.data(), ref_y.data()},
+				tar_doses.data(), tar_doses.data() + S,
+				array<const float*, 2>{tar_x.data(), tar_y.data()},
+				params
+			);
+			parallel_unsequenced_gamma_index_implementer<float, 2>::finalize_pass(output_par_unseq.data(), output_par_unseq.data() + S);
+			auto end = high_resolution_clock::now();
+			BOOST_TEST_MESSAGE("parallel unsequenced took: " << duration_cast<nanoseconds>(end - start).count() / 1e9 << 's');
+		}
+		// compare
+		{
+			auto comp = [](auto a, auto b) {return std::abs(a - b) < epsilon; };
+			auto unseq_equal_to_seq = equal(execution::par_unseq, output_seq.data(), output_seq.data() + S, output_unseq.data(), output_unseq.data() + S, comp);
+			auto par_equal_to_seq = equal(execution::par_unseq, output_seq.data(), output_seq.data() + S, output_par.data(), output_par.data() + S, comp);
+			auto par_unseq_equal_to_seq = equal(execution::par_unseq, output_seq.data(), output_seq.data() + S, output_par_unseq.data(), output_par_unseq.data() + S, comp);
+
+			BOOST_CHECK(unseq_equal_to_seq);
+			BOOST_CHECK(par_equal_to_seq);
+			BOOST_CHECK(par_unseq_equal_to_seq);
+		}
+		BOOST_TEST_MESSAGE("---- 3D ----");
+		// sequenced
+		{
+			auto start = high_resolution_clock::now();
+			sequenced_gamma_index_implementer<float, 3>::initialize_pass(output_seq.data(), output_seq.data() + S);
+			sequenced_gamma_index_implementer<float, 3>::minimize_pass(
+				output_seq.data(), output_seq.data() + S,
+				ref_doses.data(),
+				array<const float*, 3>{ref_x.data(), ref_y.data(), ref_z.data()},
+				tar_doses.data(), tar_doses.data() + S,
+				array<const float*, 3>{tar_x.data(), tar_y.data(), tar_z.data()},
+				params
+			);
+			sequenced_gamma_index_implementer<float, 3>::finalize_pass(output_seq.data(), output_seq.data() + S);
+			auto end = high_resolution_clock::now();
+			BOOST_TEST_MESSAGE("sequenced took: " << duration_cast<nanoseconds>(end - start).count() / 1e9 << 's');
+		}
+		// unsequenced
+		{
+			auto start = high_resolution_clock::now();
+			unsequenced_gamma_index_implementer<float, 3>::initialize_pass(output_unseq.data(), output_unseq.data() + S);
+			unsequenced_gamma_index_implementer<float, 3>::minimize_pass(
+				output_unseq.data(), output_unseq.data() + S,
+				ref_doses.data(),
+				array<const float*, 3>{ref_x.data(), ref_y.data(), ref_z.data()},
+				tar_doses.data(), tar_doses.data() + S,
+				array<const float*, 3>{tar_x.data(), tar_y.data(), tar_z.data()},
+				params
+			);
+			unsequenced_gamma_index_implementer<float, 3>::finalize_pass(output_unseq.data(), output_unseq.data() + S);
+			auto end = high_resolution_clock::now();
+			BOOST_TEST_MESSAGE("unsequenced took: " << duration_cast<nanoseconds>(end - start).count() / 1e9 << 's');
+		}
+		// parallel
+		{
+			auto start = high_resolution_clock::now();
+			parallel_gamma_index_implementer<float, 3>::initialize_pass(output_par.data(), output_par.data() + S);
+			parallel_gamma_index_implementer<float, 3>::minimize_pass(
+				output_par.data(), output_par.data() + S,
+				ref_doses.data(),
+				array<const float*, 3>{ref_x.data(), ref_y.data(), ref_z.data()},
+				tar_doses.data(), tar_doses.data() + S,
+				array<const float*, 3>{tar_x.data(), tar_y.data(), tar_z.data()},
+				params
+			);
+			parallel_gamma_index_implementer<float, 3>::finalize_pass(output_par.data(), output_par.data() + S);
+			auto end = high_resolution_clock::now();
+			BOOST_TEST_MESSAGE("parallel took: " << duration_cast<nanoseconds>(end - start).count() / 1e9 << 's');
+		}
+		// parallel unsequenced
+		{
+			auto start = high_resolution_clock::now();
+			parallel_unsequenced_gamma_index_implementer<float, 3>::initialize_pass(output_par_unseq.data(), output_par_unseq.data() + S);
+			parallel_unsequenced_gamma_index_implementer<float, 3>::minimize_pass(
+				output_par_unseq.data(), output_par_unseq.data() + S,
+				ref_doses.data(),
+				array<const float*, 3>{ref_x.data(), ref_y.data(), ref_z.data()},
+				tar_doses.data(), tar_doses.data() + S,
+				array<const float*, 3>{tar_x.data(), tar_y.data(), tar_z.data()},
+				params
+			);
+			parallel_unsequenced_gamma_index_implementer<float, 3>::finalize_pass(output_par_unseq.data(), output_par_unseq.data() + S);
+			auto end = high_resolution_clock::now();
+			BOOST_TEST_MESSAGE("parallel unsequenced took: " << duration_cast<nanoseconds>(end - start).count() / 1e9 << 's');
+		}
+		// compare
+		{
+			auto comp = [](auto a, auto b) {return std::abs(a - b) < epsilon; };
+			auto unseq_equal_to_seq = equal(execution::par_unseq, output_seq.data(), output_seq.data() + S, output_unseq.data(), output_unseq.data() + S, comp);
+			auto par_equal_to_seq = equal(execution::par_unseq, output_seq.data(), output_seq.data() + S, output_par.data(), output_par.data() + S, comp);
+			auto par_unseq_equal_to_seq = equal(execution::par_unseq, output_seq.data(), output_seq.data() + S, output_par_unseq.data(), output_par_unseq.data() + S, comp);
+
+			BOOST_CHECK(unseq_equal_to_seq);
+			BOOST_CHECK(par_equal_to_seq);
+			BOOST_CHECK(par_unseq_equal_to_seq);
+		}
+	}
+}
+
+BOOST_AUTO_TEST_CASE(policies_relative_correctness_double)
+{
+	BOOST_TEST_MESSAGE("------------ policies_relative_correctness_double ------------");
+
+	random_device r;
+	default_random_engine e1(r());
+	uniform_real_distribution<double> uniform_dist(0.0, 10.0);
+
+	constexpr size_t S = 1000;
+	constexpr double epsilon = 1e-9;
+
+	vector<double> output_seq(S, 0.0);
+	vector<double> output_unseq(S, 0.0);
+	vector<double> output_par(S, 0.0);
+	vector<double> output_par_unseq(S, 0.0);
+
+	vector<double> ref_doses(S, 0.0);
+	vector<double> ref_x(S, 0.0);
+	vector<double> ref_y(S, 0.0);
+	vector<double> ref_z(S, 0.0);
+
+	vector<double> tar_doses(S, 0.0);
+	vector<double> tar_x(S, 0.0);
+	vector<double> tar_y(S, 0.0);
+	vector<double> tar_z(S, 0.0);
+
+	auto gen = [&]() {return uniform_dist(e1); };
+
+	std::generate_n(ref_doses.data(), S, gen);
+	std::generate_n(ref_x.data(), S, gen);
+	std::generate_n(ref_y.data(), S, gen);
+	std::generate_n(ref_z.data(), S, gen);
+
+	std::generate_n(tar_doses.data(), S, gen);
+	std::generate_n(tar_x.data(), S, gen);
+	std::generate_n(tar_y.data(), S, gen);
+	std::generate_n(tar_z.data(), S, gen);
+
+	BOOST_TEST_MESSAGE("-------- local --------");
+	{
+		local_gamma_index_params<double> params{ 0.5f, 12.0f };
+		BOOST_TEST_MESSAGE("---- 1D ----");
+		// sequenced
+		{
+			auto start = high_resolution_clock::now();
+			sequenced_gamma_index_implementer<double, 1>::initialize_pass(output_seq.data(), output_seq.data() + S);
+			sequenced_gamma_index_implementer<double, 1>::minimize_pass(
+				output_seq.data(), output_seq.data() + S,
+				ref_doses.data(),
+				array<const double*, 1>{ref_x.data()},
+				tar_doses.data(), tar_doses.data() + S,
+				array<const double*, 1>{tar_x.data()},
+				params
+			);
+			sequenced_gamma_index_implementer<double, 1>::finalize_pass(output_seq.data(), output_seq.data() + S);
+			auto end = high_resolution_clock::now();
+			BOOST_TEST_MESSAGE("sequenced took: " << duration_cast<nanoseconds>(end - start).count() / 1e9 << 's');
+		}
+		// unsequenced
+		{
+			auto start = high_resolution_clock::now();
+			unsequenced_gamma_index_implementer<double, 1>::initialize_pass(output_unseq.data(), output_unseq.data() + S);
+			unsequenced_gamma_index_implementer<double, 1>::minimize_pass(
+				output_unseq.data(), output_unseq.data() + S,
+				ref_doses.data(),
+				array<const double*, 1>{ref_x.data()},
+				tar_doses.data(), tar_doses.data() + S,
+				array<const double*, 1>{tar_x.data()},
+				params
+			);
+			unsequenced_gamma_index_implementer<double, 1>::finalize_pass(output_unseq.data(), output_unseq.data() + S);
+			auto end = high_resolution_clock::now();
+			BOOST_TEST_MESSAGE("unsequenced took: " << duration_cast<nanoseconds>(end - start).count() / 1e9 << 's');
+		}
+		// parallel
+		{
+			auto start = high_resolution_clock::now();
+			parallel_gamma_index_implementer<double, 1>::initialize_pass(output_par.data(), output_par.data() + S);
+			parallel_gamma_index_implementer<double, 1>::minimize_pass(
+				output_par.data(), output_par.data() + S,
+				ref_doses.data(),
+				array<const double*, 1>{ref_x.data()},
+				tar_doses.data(), tar_doses.data() + S,
+				array<const double*, 1>{tar_x.data()},
+				params
+			);
+			parallel_gamma_index_implementer<double, 1>::finalize_pass(output_par.data(), output_par.data() + S);
+			auto end = high_resolution_clock::now();
+			BOOST_TEST_MESSAGE("parallel took: " << duration_cast<nanoseconds>(end - start).count() / 1e9 << 's');
+		}
+		// parallel unsequenced
+		{
+			auto start = high_resolution_clock::now();
+			parallel_unsequenced_gamma_index_implementer<double, 1>::initialize_pass(output_par_unseq.data(), output_par_unseq.data() + S);
+			parallel_unsequenced_gamma_index_implementer<double, 1>::minimize_pass(
+				output_par_unseq.data(), output_par_unseq.data() + S,
+				ref_doses.data(),
+				array<const double*, 1>{ref_x.data()},
+				tar_doses.data(), tar_doses.data() + S,
+				array<const double*, 1>{tar_x.data()},
+				params
+			);
+			parallel_unsequenced_gamma_index_implementer<double, 1>::finalize_pass(output_par_unseq.data(), output_par_unseq.data() + S);
+			auto end = high_resolution_clock::now();
+			BOOST_TEST_MESSAGE("parallel unsequenced took: " << duration_cast<nanoseconds>(end - start).count() / 1e9 << 's');
+		}
+		// compare
+		{
+			auto comp = [](auto a, auto b) {return std::abs(a - b) < epsilon; };
+			auto unseq_equal_to_seq = equal(execution::par_unseq, output_seq.data(), output_seq.data() + S, output_unseq.data(), output_unseq.data() + S, comp);
+			auto par_equal_to_seq = equal(execution::par_unseq, output_seq.data(), output_seq.data() + S, output_par.data(), output_par.data() + S, comp);
+			auto par_unseq_equal_to_seq = equal(execution::par_unseq, output_seq.data(), output_seq.data() + S, output_par_unseq.data(), output_par_unseq.data() + S, comp);
+
+			BOOST_CHECK(unseq_equal_to_seq);
+			BOOST_CHECK(par_equal_to_seq);
+			BOOST_CHECK(par_unseq_equal_to_seq);
+		}
+		BOOST_TEST_MESSAGE("---- 2D ----");
+		// sequenced
+		{
+			auto start = high_resolution_clock::now();
+			sequenced_gamma_index_implementer<double, 2>::initialize_pass(output_seq.data(), output_seq.data() + S);
+			sequenced_gamma_index_implementer<double, 2>::minimize_pass(
+				output_seq.data(), output_seq.data() + S,
+				ref_doses.data(),
+				array<const double*, 2>{ref_x.data(), ref_y.data()},
+				tar_doses.data(), tar_doses.data() + S,
+				array<const double*, 2>{tar_x.data(), tar_y.data()},
+				params
+			);
+			sequenced_gamma_index_implementer<double, 2>::finalize_pass(output_seq.data(), output_seq.data() + S);
+			auto end = high_resolution_clock::now();
+			BOOST_TEST_MESSAGE("sequenced took: " << duration_cast<nanoseconds>(end - start).count() / 1e9 << 's');
+		}
+		// unsequenced
+		{
+			auto start = high_resolution_clock::now();
+			unsequenced_gamma_index_implementer<double, 2>::initialize_pass(output_unseq.data(), output_unseq.data() + S);
+			unsequenced_gamma_index_implementer<double, 2>::minimize_pass(
+				output_unseq.data(), output_unseq.data() + S,
+				ref_doses.data(),
+				array<const double*, 2>{ref_x.data(), ref_y.data()},
+				tar_doses.data(), tar_doses.data() + S,
+				array<const double*, 2>{tar_x.data(), tar_y.data()},
+				params
+			);
+			unsequenced_gamma_index_implementer<double, 2>::finalize_pass(output_unseq.data(), output_unseq.data() + S);
+			auto end = high_resolution_clock::now();
+			BOOST_TEST_MESSAGE("unsequenced took: " << duration_cast<nanoseconds>(end - start).count() / 1e9 << 's');
+		}
+		// parallel
+		{
+			auto start = high_resolution_clock::now();
+			parallel_gamma_index_implementer<double, 2>::initialize_pass(output_par.data(), output_par.data() + S);
+			parallel_gamma_index_implementer<double, 2>::minimize_pass(
+				output_par.data(), output_par.data() + S,
+				ref_doses.data(),
+				array<const double*, 2>{ref_x.data(), ref_y.data()},
+				tar_doses.data(), tar_doses.data() + S,
+				array<const double*, 2>{tar_x.data(), tar_y.data()},
+				params
+			);
+			parallel_gamma_index_implementer<double, 2>::finalize_pass(output_par.data(), output_par.data() + S);
+			auto end = high_resolution_clock::now();
+			BOOST_TEST_MESSAGE("parallel took: " << duration_cast<nanoseconds>(end - start).count() / 1e9 << 's');
+		}
+		// parallel unsequenced
+		{
+			auto start = high_resolution_clock::now();
+			parallel_unsequenced_gamma_index_implementer<double, 2>::initialize_pass(output_par_unseq.data(), output_par_unseq.data() + S);
+			parallel_unsequenced_gamma_index_implementer<double, 2>::minimize_pass(
+				output_par_unseq.data(), output_par_unseq.data() + S,
+				ref_doses.data(),
+				array<const double*, 2>{ref_x.data(), ref_y.data()},
+				tar_doses.data(), tar_doses.data() + S,
+				array<const double*, 2>{tar_x.data(), tar_y.data()},
+				params
+			);
+			parallel_unsequenced_gamma_index_implementer<double, 2>::finalize_pass(output_par_unseq.data(), output_par_unseq.data() + S);
+			auto end = high_resolution_clock::now();
+			BOOST_TEST_MESSAGE("parallel unsequenced took: " << duration_cast<nanoseconds>(end - start).count() / 1e9 << 's');
+		}
+		// compare
+		{
+			auto comp = [](auto a, auto b) {return std::abs(a - b) < epsilon; };
+			auto unseq_equal_to_seq = equal(execution::par_unseq, output_seq.data(), output_seq.data() + S, output_unseq.data(), output_unseq.data() + S, comp);
+			auto par_equal_to_seq = equal(execution::par_unseq, output_seq.data(), output_seq.data() + S, output_par.data(), output_par.data() + S, comp);
+			auto par_unseq_equal_to_seq = equal(execution::par_unseq, output_seq.data(), output_seq.data() + S, output_par_unseq.data(), output_par_unseq.data() + S, comp);
+
+			BOOST_CHECK(unseq_equal_to_seq);
+			BOOST_CHECK(par_equal_to_seq);
+			BOOST_CHECK(par_unseq_equal_to_seq);
+		}
+		BOOST_TEST_MESSAGE("---- 3D ----");
+		// sequenced
+		{
+			auto start = high_resolution_clock::now();
+			sequenced_gamma_index_implementer<double, 3>::initialize_pass(output_seq.data(), output_seq.data() + S);
+			sequenced_gamma_index_implementer<double, 3>::minimize_pass(
+				output_seq.data(), output_seq.data() + S,
+				ref_doses.data(),
+				array<const double*, 3>{ref_x.data(), ref_y.data(), ref_z.data()},
+				tar_doses.data(), tar_doses.data() + S,
+				array<const double*, 3>{tar_x.data(), tar_y.data(), tar_z.data()},
+				params
+			);
+			sequenced_gamma_index_implementer<double, 3>::finalize_pass(output_seq.data(), output_seq.data() + S);
+			auto end = high_resolution_clock::now();
+			BOOST_TEST_MESSAGE("sequenced took: " << duration_cast<nanoseconds>(end - start).count() / 1e9 << 's');
+		}
+		// unsequenced
+		{
+			auto start = high_resolution_clock::now();
+			unsequenced_gamma_index_implementer<double, 3>::initialize_pass(output_unseq.data(), output_unseq.data() + S);
+			unsequenced_gamma_index_implementer<double, 3>::minimize_pass(
+				output_unseq.data(), output_unseq.data() + S,
+				ref_doses.data(),
+				array<const double*, 3>{ref_x.data(), ref_y.data(), ref_z.data()},
+				tar_doses.data(), tar_doses.data() + S,
+				array<const double*, 3>{tar_x.data(), tar_y.data(), tar_z.data()},
+				params
+			);
+			unsequenced_gamma_index_implementer<double, 3>::finalize_pass(output_unseq.data(), output_unseq.data() + S);
+			auto end = high_resolution_clock::now();
+			BOOST_TEST_MESSAGE("unsequenced took: " << duration_cast<nanoseconds>(end - start).count() / 1e9 << 's');
+		}
+		// parallel
+		{
+			auto start = high_resolution_clock::now();
+			parallel_gamma_index_implementer<double, 3>::initialize_pass(output_par.data(), output_par.data() + S);
+			parallel_gamma_index_implementer<double, 3>::minimize_pass(
+				output_par.data(), output_par.data() + S,
+				ref_doses.data(),
+				array<const double*, 3>{ref_x.data(), ref_y.data(), ref_z.data()},
+				tar_doses.data(), tar_doses.data() + S,
+				array<const double*, 3>{tar_x.data(), tar_y.data(), tar_z.data()},
+				params
+			);
+			parallel_gamma_index_implementer<double, 3>::finalize_pass(output_par.data(), output_par.data() + S);
+			auto end = high_resolution_clock::now();
+			BOOST_TEST_MESSAGE("parallel took: " << duration_cast<nanoseconds>(end - start).count() / 1e9 << 's');
+		}
+		// parallel unsequenced
+		{
+			auto start = high_resolution_clock::now();
+			parallel_unsequenced_gamma_index_implementer<double, 3>::initialize_pass(output_par_unseq.data(), output_par_unseq.data() + S);
+			parallel_unsequenced_gamma_index_implementer<double, 3>::minimize_pass(
+				output_par_unseq.data(), output_par_unseq.data() + S,
+				ref_doses.data(),
+				array<const double*, 3>{ref_x.data(), ref_y.data(), ref_z.data()},
+				tar_doses.data(), tar_doses.data() + S,
+				array<const double*, 3>{tar_x.data(), tar_y.data(), tar_z.data()},
+				params
+			);
+			parallel_unsequenced_gamma_index_implementer<double, 3>::finalize_pass(output_par_unseq.data(), output_par_unseq.data() + S);
+			auto end = high_resolution_clock::now();
+			BOOST_TEST_MESSAGE("parallel unsequenced took: " << duration_cast<nanoseconds>(end - start).count() / 1e9 << 's');
+		}
+		// compare
+		{
+			auto comp = [](auto a, auto b) {return std::abs(a - b) < epsilon; };
+			auto unseq_equal_to_seq = equal(execution::par_unseq, output_seq.data(), output_seq.data() + S, output_unseq.data(), output_unseq.data() + S, comp);
+			auto par_equal_to_seq = equal(execution::par_unseq, output_seq.data(), output_seq.data() + S, output_par.data(), output_par.data() + S, comp);
+			auto par_unseq_equal_to_seq = equal(execution::par_unseq, output_seq.data(), output_seq.data() + S, output_par_unseq.data(), output_par_unseq.data() + S, comp);
+
+			BOOST_CHECK(unseq_equal_to_seq);
+			BOOST_CHECK(par_equal_to_seq);
+			BOOST_CHECK(par_unseq_equal_to_seq);
+		}
+	}
+
+	BOOST_TEST_MESSAGE("-------- global --------");
+	{
+		global_gamma_index_params<double> params{ 0.5f, 12.0f };
+		BOOST_TEST_MESSAGE("---- 1D ----");
+		// sequenced
+		{
+			auto start = high_resolution_clock::now();
+			sequenced_gamma_index_implementer<double, 1>::initialize_pass(output_seq.data(), output_seq.data() + S);
+			sequenced_gamma_index_implementer<double, 1>::minimize_pass(
+				output_seq.data(), output_seq.data() + S,
+				ref_doses.data(),
+				array<const double*, 1>{ref_x.data()},
+				tar_doses.data(), tar_doses.data() + S,
+				array<const double*, 1>{tar_x.data()},
+				params
+			);
+			sequenced_gamma_index_implementer<double, 1>::finalize_pass(output_seq.data(), output_seq.data() + S);
+			auto end = high_resolution_clock::now();
+			BOOST_TEST_MESSAGE("sequenced took: " << duration_cast<nanoseconds>(end - start).count() / 1e9 << 's');
+		}
+		// unsequenced
+		{
+			auto start = high_resolution_clock::now();
+			unsequenced_gamma_index_implementer<double, 1>::initialize_pass(output_unseq.data(), output_unseq.data() + S);
+			unsequenced_gamma_index_implementer<double, 1>::minimize_pass(
+				output_unseq.data(), output_unseq.data() + S,
+				ref_doses.data(),
+				array<const double*, 1>{ref_x.data()},
+				tar_doses.data(), tar_doses.data() + S,
+				array<const double*, 1>{tar_x.data()},
+				params
+			);
+			unsequenced_gamma_index_implementer<double, 1>::finalize_pass(output_unseq.data(), output_unseq.data() + S);
+			auto end = high_resolution_clock::now();
+			BOOST_TEST_MESSAGE("unsequenced took: " << duration_cast<nanoseconds>(end - start).count() / 1e9 << 's');
+		}
+		// parallel
+		{
+			auto start = high_resolution_clock::now();
+			parallel_gamma_index_implementer<double, 1>::initialize_pass(output_par.data(), output_par.data() + S);
+			parallel_gamma_index_implementer<double, 1>::minimize_pass(
+				output_par.data(), output_par.data() + S,
+				ref_doses.data(),
+				array<const double*, 1>{ref_x.data()},
+				tar_doses.data(), tar_doses.data() + S,
+				array<const double*, 1>{tar_x.data()},
+				params
+			);
+			parallel_gamma_index_implementer<double, 1>::finalize_pass(output_par.data(), output_par.data() + S);
+			auto end = high_resolution_clock::now();
+			BOOST_TEST_MESSAGE("parallel took: " << duration_cast<nanoseconds>(end - start).count() / 1e9 << 's');
+		}
+		// parallel unsequenced
+		{
+			auto start = high_resolution_clock::now();
+			parallel_unsequenced_gamma_index_implementer<double, 1>::initialize_pass(output_par_unseq.data(), output_par_unseq.data() + S);
+			parallel_unsequenced_gamma_index_implementer<double, 1>::minimize_pass(
+				output_par_unseq.data(), output_par_unseq.data() + S,
+				ref_doses.data(),
+				array<const double*, 1>{ref_x.data()},
+				tar_doses.data(), tar_doses.data() + S,
+				array<const double*, 1>{tar_x.data()},
+				params
+			);
+			parallel_unsequenced_gamma_index_implementer<double, 1>::finalize_pass(output_par_unseq.data(), output_par_unseq.data() + S);
+			auto end = high_resolution_clock::now();
+			BOOST_TEST_MESSAGE("parallel unsequenced took: " << duration_cast<nanoseconds>(end - start).count() / 1e9 << 's');
+		}
+		// compare
+		{
+			auto comp = [](auto a, auto b) {return std::abs(a - b) < epsilon; };
+			auto unseq_equal_to_seq = equal(execution::par_unseq, output_seq.data(), output_seq.data() + S, output_unseq.data(), output_unseq.data() + S, comp);
+			auto par_equal_to_seq = equal(execution::par_unseq, output_seq.data(), output_seq.data() + S, output_par.data(), output_par.data() + S, comp);
+			auto par_unseq_equal_to_seq = equal(execution::par_unseq, output_seq.data(), output_seq.data() + S, output_par_unseq.data(), output_par_unseq.data() + S, comp);
+
+			BOOST_CHECK(unseq_equal_to_seq);
+			BOOST_CHECK(par_equal_to_seq);
+			BOOST_CHECK(par_unseq_equal_to_seq);
+		}
+		BOOST_TEST_MESSAGE("---- 2D ----");
+		// sequenced
+		{
+			auto start = high_resolution_clock::now();
+			sequenced_gamma_index_implementer<double, 2>::initialize_pass(output_seq.data(), output_seq.data() + S);
+			sequenced_gamma_index_implementer<double, 2>::minimize_pass(
+				output_seq.data(), output_seq.data() + S,
+				ref_doses.data(),
+				array<const double*, 2>{ref_x.data(), ref_y.data()},
+				tar_doses.data(), tar_doses.data() + S,
+				array<const double*, 2>{tar_x.data(), tar_y.data()},
+				params
+			);
+			sequenced_gamma_index_implementer<double, 2>::finalize_pass(output_seq.data(), output_seq.data() + S);
+			auto end = high_resolution_clock::now();
+			BOOST_TEST_MESSAGE("sequenced took: " << duration_cast<nanoseconds>(end - start).count() / 1e9 << 's');
+		}
+		// unsequenced
+		{
+			auto start = high_resolution_clock::now();
+			unsequenced_gamma_index_implementer<double, 2>::initialize_pass(output_unseq.data(), output_unseq.data() + S);
+			unsequenced_gamma_index_implementer<double, 2>::minimize_pass(
+				output_unseq.data(), output_unseq.data() + S,
+				ref_doses.data(),
+				array<const double*, 2>{ref_x.data(), ref_y.data()},
+				tar_doses.data(), tar_doses.data() + S,
+				array<const double*, 2>{tar_x.data(), tar_y.data()},
+				params
+			);
+			unsequenced_gamma_index_implementer<double, 2>::finalize_pass(output_unseq.data(), output_unseq.data() + S);
+			auto end = high_resolution_clock::now();
+			BOOST_TEST_MESSAGE("unsequenced took: " << duration_cast<nanoseconds>(end - start).count() / 1e9 << 's');
+		}
+		// parallel
+		{
+			auto start = high_resolution_clock::now();
+			parallel_gamma_index_implementer<double, 2>::initialize_pass(output_par.data(), output_par.data() + S);
+			parallel_gamma_index_implementer<double, 2>::minimize_pass(
+				output_par.data(), output_par.data() + S,
+				ref_doses.data(),
+				array<const double*, 2>{ref_x.data(), ref_y.data()},
+				tar_doses.data(), tar_doses.data() + S,
+				array<const double*, 2>{tar_x.data(), tar_y.data()},
+				params
+			);
+			parallel_gamma_index_implementer<double, 2>::finalize_pass(output_par.data(), output_par.data() + S);
+			auto end = high_resolution_clock::now();
+			BOOST_TEST_MESSAGE("parallel took: " << duration_cast<nanoseconds>(end - start).count() / 1e9 << 's');
+		}
+		// parallel unsequenced
+		{
+			auto start = high_resolution_clock::now();
+			parallel_unsequenced_gamma_index_implementer<double, 2>::initialize_pass(output_par_unseq.data(), output_par_unseq.data() + S);
+			parallel_unsequenced_gamma_index_implementer<double, 2>::minimize_pass(
+				output_par_unseq.data(), output_par_unseq.data() + S,
+				ref_doses.data(),
+				array<const double*, 2>{ref_x.data(), ref_y.data()},
+				tar_doses.data(), tar_doses.data() + S,
+				array<const double*, 2>{tar_x.data(), tar_y.data()},
+				params
+			);
+			parallel_unsequenced_gamma_index_implementer<double, 2>::finalize_pass(output_par_unseq.data(), output_par_unseq.data() + S);
+			auto end = high_resolution_clock::now();
+			BOOST_TEST_MESSAGE("parallel unsequenced took: " << duration_cast<nanoseconds>(end - start).count() / 1e9 << 's');
+		}
+		// compare
+		{
+			auto comp = [](auto a, auto b) {return std::abs(a - b) < epsilon; };
+			auto unseq_equal_to_seq = equal(execution::par_unseq, output_seq.data(), output_seq.data() + S, output_unseq.data(), output_unseq.data() + S, comp);
+			auto par_equal_to_seq = equal(execution::par_unseq, output_seq.data(), output_seq.data() + S, output_par.data(), output_par.data() + S, comp);
+			auto par_unseq_equal_to_seq = equal(execution::par_unseq, output_seq.data(), output_seq.data() + S, output_par_unseq.data(), output_par_unseq.data() + S, comp);
+
+			BOOST_CHECK(unseq_equal_to_seq);
+			BOOST_CHECK(par_equal_to_seq);
+			BOOST_CHECK(par_unseq_equal_to_seq);
+		}
+		BOOST_TEST_MESSAGE("---- 3D ----");
+		// sequenced
+		{
+			auto start = high_resolution_clock::now();
+			sequenced_gamma_index_implementer<double, 3>::initialize_pass(output_seq.data(), output_seq.data() + S);
+			sequenced_gamma_index_implementer<double, 3>::minimize_pass(
+				output_seq.data(), output_seq.data() + S,
+				ref_doses.data(),
+				array<const double*, 3>{ref_x.data(), ref_y.data(), ref_z.data()},
+				tar_doses.data(), tar_doses.data() + S,
+				array<const double*, 3>{tar_x.data(), tar_y.data(), tar_z.data()},
+				params
+			);
+			sequenced_gamma_index_implementer<double, 3>::finalize_pass(output_seq.data(), output_seq.data() + S);
+			auto end = high_resolution_clock::now();
+			BOOST_TEST_MESSAGE("sequenced took: " << duration_cast<nanoseconds>(end - start).count() / 1e9 << 's');
+		}
+		// unsequenced
+		{
+			auto start = high_resolution_clock::now();
+			unsequenced_gamma_index_implementer<double, 3>::initialize_pass(output_unseq.data(), output_unseq.data() + S);
+			unsequenced_gamma_index_implementer<double, 3>::minimize_pass(
+				output_unseq.data(), output_unseq.data() + S,
+				ref_doses.data(),
+				array<const double*, 3>{ref_x.data(), ref_y.data(), ref_z.data()},
+				tar_doses.data(), tar_doses.data() + S,
+				array<const double*, 3>{tar_x.data(), tar_y.data(), tar_z.data()},
+				params
+			);
+			unsequenced_gamma_index_implementer<double, 3>::finalize_pass(output_unseq.data(), output_unseq.data() + S);
+			auto end = high_resolution_clock::now();
+			BOOST_TEST_MESSAGE("unsequenced took: " << duration_cast<nanoseconds>(end - start).count() / 1e9 << 's');
+		}
+		// parallel
+		{
+			auto start = high_resolution_clock::now();
+			parallel_gamma_index_implementer<double, 3>::initialize_pass(output_par.data(), output_par.data() + S);
+			parallel_gamma_index_implementer<double, 3>::minimize_pass(
+				output_par.data(), output_par.data() + S,
+				ref_doses.data(),
+				array<const double*, 3>{ref_x.data(), ref_y.data(), ref_z.data()},
+				tar_doses.data(), tar_doses.data() + S,
+				array<const double*, 3>{tar_x.data(), tar_y.data(), tar_z.data()},
+				params
+			);
+			parallel_gamma_index_implementer<double, 3>::finalize_pass(output_par.data(), output_par.data() + S);
+			auto end = high_resolution_clock::now();
+			BOOST_TEST_MESSAGE("parallel took: " << duration_cast<nanoseconds>(end - start).count() / 1e9 << 's');
+		}
+		// parallel unsequenced
+		{
+			auto start = high_resolution_clock::now();
+			parallel_unsequenced_gamma_index_implementer<double, 3>::initialize_pass(output_par_unseq.data(), output_par_unseq.data() + S);
+			parallel_unsequenced_gamma_index_implementer<double, 3>::minimize_pass(
+				output_par_unseq.data(), output_par_unseq.data() + S,
+				ref_doses.data(),
+				array<const double*, 3>{ref_x.data(), ref_y.data(), ref_z.data()},
+				tar_doses.data(), tar_doses.data() + S,
+				array<const double*, 3>{tar_x.data(), tar_y.data(), tar_z.data()},
+				params
+			);
+			parallel_unsequenced_gamma_index_implementer<double, 3>::finalize_pass(output_par_unseq.data(), output_par_unseq.data() + S);
+			auto end = high_resolution_clock::now();
+			BOOST_TEST_MESSAGE("parallel unsequenced took: " << duration_cast<nanoseconds>(end - start).count() / 1e9 << 's');
+		}
+		// compare
+		{
+			auto comp = [](auto a, auto b) {return std::abs(a - b) < epsilon; };
+			auto unseq_equal_to_seq = equal(execution::par_unseq, output_seq.data(), output_seq.data() + S, output_unseq.data(), output_unseq.data() + S, comp);
+			auto par_equal_to_seq = equal(execution::par_unseq, output_seq.data(), output_seq.data() + S, output_par.data(), output_par.data() + S, comp);
+			auto par_unseq_equal_to_seq = equal(execution::par_unseq, output_seq.data(), output_seq.data() + S, output_par_unseq.data(), output_par_unseq.data() + S, comp);
+
+			BOOST_CHECK(unseq_equal_to_seq);
+			BOOST_CHECK(par_equal_to_seq);
+			BOOST_CHECK(par_unseq_equal_to_seq);
+		}
+	}
+}
+
+BOOST_AUTO_TEST_CASE(performance_check_float)
+{
+	BOOST_TEST_MESSAGE("------------ performance_check_float parallel_unsequenced only ------------");
+	random_device r;
+	default_random_engine e1(r());
+	uniform_real_distribution<float> uniform_dist(0.0, 10.0f);
+
+	constexpr size_t S = 1000000;
+	constexpr float epsilon = 1e-4;
+
+	vector<float> output_par_unseq(S, 0.0f);
+
+	vector<float> ref_doses(S, 0.0f);
+	vector<float> ref_x(S, 0.0f);
+	vector<float> ref_y(S, 0.0f);
+	vector<float> ref_z(S, 0.0f);
+
+	vector<float> tar_doses(S, 0.0f);
+	vector<float> tar_x(S, 0.0f);
+	vector<float> tar_y(S, 0.0f);
+	vector<float> tar_z(S, 0.0f);
+
+	auto gen = [&]() {return uniform_dist(e1); };
+
+	std::generate_n(ref_doses.data(), S, gen);
+	std::generate_n(ref_x.data(), S, gen);
+	std::generate_n(ref_y.data(), S, gen);
+	std::generate_n(ref_z.data(), S, gen);
+
+	std::generate_n(tar_doses.data(), S, gen);
+	std::generate_n(tar_x.data(), S, gen);
+	std::generate_n(tar_y.data(), S, gen);
+	std::generate_n(tar_z.data(), S, gen);
+
+	local_gamma_index_params<float> params{ 0.5f, 12.0f };
+
+	auto start = high_resolution_clock::now();
+	parallel_unsequenced_gamma_index_implementer<float, 3>::initialize_pass(output_par_unseq.data(), output_par_unseq.data() + S);
+	parallel_unsequenced_gamma_index_implementer<float, 3>::minimize_pass(
+		output_par_unseq.data(), output_par_unseq.data() + S,
+		ref_doses.data(),
+		array<const float*, 3>{ref_x.data(), ref_y.data(), ref_z.data()},
+		tar_doses.data(), tar_doses.data() + S,
+		array<const float*, 3>{tar_x.data(), tar_y.data(), tar_z.data()},
+		params
+	);
+	parallel_unsequenced_gamma_index_implementer<float, 3>::finalize_pass(output_par_unseq.data(), output_par_unseq.data() + S);
+	auto end = high_resolution_clock::now();
+	BOOST_TEST_MESSAGE("parallel unsequenced took (1000x1000 random image): " << duration_cast<nanoseconds>(end - start).count() / 1e9 << 's');
+}
+
+BOOST_AUTO_TEST_CASE(performance_check_double)
+{
+	BOOST_TEST_MESSAGE("------------ performance_check_double parallel_unsequenced only ------------");
+	random_device r;
+	default_random_engine e1(r());
+	uniform_real_distribution<double> uniform_dist(0.0, 10.0f);
+
+	constexpr size_t S = 10000000;
+	constexpr double epsilon = 1e-9;
+
+	vector<double> output_par_unseq(S, 0.0);
+
+	vector<double> ref_doses(S, 0.0);
+	vector<double> ref_x(S, 0.0);
+	vector<double> ref_y(S, 0.0);
+	vector<double> ref_z(S, 0.0);
+
+	vector<double> tar_doses(S, 0.0);
+	vector<double> tar_x(S, 0.0);
+	vector<double> tar_y(S, 0.0);
+	vector<double> tar_z(S, 0.0);
+
+	auto gen = [&]() {return uniform_dist(e1); };
+
+	std::generate_n(ref_doses.data(), S, gen);
+	std::generate_n(ref_x.data(), S, gen);
+	std::generate_n(ref_y.data(), S, gen);
+	std::generate_n(ref_z.data(), S, gen);
+
+	std::generate_n(tar_doses.data(), S, gen);
+	std::generate_n(tar_x.data(), S, gen);
+	std::generate_n(tar_y.data(), S, gen);
+	std::generate_n(tar_z.data(), S, gen);
+
+	local_gamma_index_params<double> params{ 0.5f, 12.0f };
+
+	auto start = high_resolution_clock::now();
+	parallel_unsequenced_gamma_index_implementer<double, 3>::initialize_pass(output_par_unseq.data(), output_par_unseq.data() + S);
+	parallel_unsequenced_gamma_index_implementer<double, 3>::minimize_pass(
+		output_par_unseq.data(), output_par_unseq.data() + S,
+		ref_doses.data(),
+		array<const double*, 3>{ref_x.data(), ref_y.data(), ref_z.data()},
+		tar_doses.data(), tar_doses.data() + S,
+		array<const double*, 3>{tar_x.data(), tar_y.data(), tar_z.data()},
+		params
+	);
+	parallel_unsequenced_gamma_index_implementer<double, 3>::finalize_pass(output_par_unseq.data(), output_par_unseq.data() + S);
+	auto end = high_resolution_clock::now();
+	BOOST_TEST_MESSAGE("parallel unsequenced took (1000x1000 random image): " << duration_cast<nanoseconds>(end - start).count() / 1e9 << 's');
+}
+
+BOOST_AUTO_TEST_CASE(performance_vs_original_spiral_rectangle)
+{
+	BOOST_TEST_MESSAGE("------------ performance_vs_original_spiral_rectangle parallel_unsequenced vs spiral_rectangle ------------");
+	random_device r;
+	default_random_engine e1(r());
+	uniform_real_distribution<double> uniform_dist(0.0, 10.0f);
+	auto gen = [&]() {return uniform_dist(e1); };
+
+	constexpr size_t SX = 100;
+	constexpr size_t SY = 10;
+	constexpr size_t SZ = 10;
+	constexpr size_t S = SX * SY * SZ;
+	constexpr double epsilon = 1e-9;
+
+	// original format
+	vector<double> ref_start = { 0.0,0.0,0.0 };
+	vector<double> ref_spacing = { 0.5,0.2,0.3 };
+	vector<vector<vector<double>>> ref_data(SX, vector<vector<double>>(SY, vector<double>(SZ, 0.0)));
+
+	for (auto& vv : ref_data)
+		for (auto& v : vv)
+			for (auto& e : v)
+				e = gen();
+
+	Image3D img_ref = Image3D(ref_start, ref_spacing, ref_data);
+
+	vector<double> tar_start = { -0.5,0.3,0.2 };
+	vector<double> tar_spacing = { 0.4,0.1,0.4 };
+	vector<vector<vector<double>>> tar_data(SX, vector<vector<double>>(SY, vector<double>(SZ, 0.0)));
+
+	for (auto& vv : tar_data)
+		for (auto& v : vv)
+			for (auto& e : v)
+				e = gen();
+
+	Image3D img_tar = Image3D(tar_start, tar_spacing, tar_data);
+
+	SpiralNoRectangleSolver3D solver = SpiralNoRectangleSolver3D(img_ref, img_tar, 0.5f, 0.5f);
+
+	// after optimizations
+	vector<double> output_par_unseq(S, 0.0);
+
+	vector<double> ref_doses(S, 0.0);
+	vector<double> ref_x(S, 0.0);
+	vector<double> ref_y(S, 0.0);
+	vector<double> ref_z(S, 0.0);
+
+	vector<double> tar_doses(S, 0.0);
+	vector<double> tar_x(S, 0.0);
+	vector<double> tar_y(S, 0.0);
+	vector<double> tar_z(S, 0.0);
+
+	for (size_t x = 0; x < SX; x++)
+		for (size_t y = 0; y < SY; y++)
+			for (size_t z = 0; z < SZ; z++)
+			{
+				auto i = x * SY * SZ + y * SZ + z;
+				
+				ref_doses[i] = ref_data[x][y][z];
+				ref_x[i] = ref_start[0] + ref_spacing[0] * x;
+				ref_y[i] = ref_start[1] + ref_spacing[1] * y;
+				ref_z[i] = ref_start[2] + ref_spacing[2] * z;
+
+				tar_doses[i] = tar_data[x][y][z];
+				tar_x[i] = tar_start[0] + tar_spacing[0] * x;
+				tar_y[i] = tar_start[1] + tar_spacing[1] * y;
+				tar_z[i] = tar_start[2] + tar_spacing[2] * z;
+			}
+
+	local_gamma_index_params<double> params{ 0.5f, 0.5f };
+
+	{
+		auto start = high_resolution_clock::now();
+		Image3D result = solver.calculateGamma();
+		auto end = high_resolution_clock::now();
+		BOOST_TEST_MESSAGE("original spiral with took (" << SX << 'x' << SY << 'x' << SZ << " random image) : " << duration_cast<nanoseconds>(end - start).count() / 1e9 << 's');
+	}
+	{
+		auto start = high_resolution_clock::now();
+		parallel_unsequenced_gamma_index_implementer<double, 3>::initialize_pass(output_par_unseq.data(), output_par_unseq.data() + S);
+		parallel_unsequenced_gamma_index_implementer<double, 3>::minimize_pass(
+			output_par_unseq.data(), output_par_unseq.data() + S,
+			ref_doses.data(),
+			array<const double*, 3>{ref_x.data(), ref_y.data(), ref_z.data()},
+			tar_doses.data(), tar_doses.data() + S,
+			array<const double*, 3>{tar_x.data(), tar_y.data(), tar_z.data()},
+			params
+		);
+		parallel_unsequenced_gamma_index_implementer<double, 3>::finalize_pass(output_par_unseq.data(), output_par_unseq.data() + S);
+		auto end = high_resolution_clock::now();
+		BOOST_TEST_MESSAGE("parallel unsequenced took (" << SX << 'x' << SY << 'x' << SZ << " random image): " << duration_cast<nanoseconds>(end - start).count() / 1e9 << 's');
+	}
+}
+
+void expected_specializations_compile_without_errors()
+{
+	// float32
+	{
+		// 1
+		{
+			auto& out = *(iwritable_image<float, 1>*)(nullptr);
+			auto& ref = *(irtdose_image<float, 1>*)(nullptr);
+			auto& tar = *(irtdose_image<float, 1>*)(nullptr);
+			local_gamma_index_params<float> lp{ 0,0 };
+			global_gamma_index_params<float> gp{ 0,0 };
+
+			gamma_index(std::execution::seq, out, ref, tar, lp);
+			gamma_index(std::execution::seq, out, ref, tar, gp);
+
+			gamma_index(std::execution::unseq, out, ref, tar, lp);
+			gamma_index(std::execution::unseq, out, ref, tar, gp);
+
+			gamma_index(std::execution::par, out, ref, tar, lp);
+			gamma_index(std::execution::par, out, ref, tar, gp);
+
+			gamma_index(std::execution::par_unseq, out, ref, tar, lp);
+			gamma_index(std::execution::par_unseq, out, ref, tar, gp);
+		}
+		// 2
+		{
+			auto& out = *(iwritable_image<float, 2>*)(nullptr);
+			auto& ref = *(irtdose_image<float, 2>*)(nullptr);
+			auto& tar = *(irtdose_image<float, 2>*)(nullptr);
+			local_gamma_index_params<float> lp{ 0,0 };
+			global_gamma_index_params<float> gp{ 0,0 };
+
+			gamma_index(std::execution::seq, out, ref, tar, lp);
+			gamma_index(std::execution::seq, out, ref, tar, gp);
+
+			gamma_index(std::execution::unseq, out, ref, tar, lp);
+			gamma_index(std::execution::unseq, out, ref, tar, gp);
+
+			gamma_index(std::execution::par, out, ref, tar, lp);
+			gamma_index(std::execution::par, out, ref, tar, gp);
+
+			gamma_index(std::execution::par_unseq, out, ref, tar, lp);
+			gamma_index(std::execution::par_unseq, out, ref, tar, gp);
+		}
+		// 3
+		{
+			auto& out = *(iwritable_image<float, 3>*)(nullptr);
+			auto& ref = *(irtdose_image<float, 3>*)(nullptr);
+			auto& tar = *(irtdose_image<float, 3>*)(nullptr);
+			local_gamma_index_params<float> lp{ 0,0 };
+			global_gamma_index_params<float> gp{ 0,0 };
+
+			gamma_index(std::execution::seq, out, ref, tar, lp);
+			gamma_index(std::execution::seq, out, ref, tar, gp);
+
+			gamma_index(std::execution::unseq, out, ref, tar, lp);
+			gamma_index(std::execution::unseq, out, ref, tar, gp);
+
+			gamma_index(std::execution::par, out, ref, tar, lp);
+			gamma_index(std::execution::par, out, ref, tar, gp);
+
+			gamma_index(std::execution::par_unseq, out, ref, tar, lp);
+			gamma_index(std::execution::par_unseq, out, ref, tar, gp);
+		}
+	}
+	// float64
+	{
+		// 1
+		{
+			auto& out = *(iwritable_image<double, 1>*)(nullptr);
+			auto& ref = *(irtdose_image<double, 1>*)(nullptr);
+			auto& tar = *(irtdose_image<double, 1>*)(nullptr);
+			local_gamma_index_params<double> lp{ 0,0 };
+			global_gamma_index_params<double> gp{ 0,0 };
+
+			gamma_index(std::execution::seq, out, ref, tar, lp);
+			gamma_index(std::execution::seq, out, ref, tar, gp);
+
+			gamma_index(std::execution::unseq, out, ref, tar, lp);
+			gamma_index(std::execution::unseq, out, ref, tar, gp);
+
+			gamma_index(std::execution::par, out, ref, tar, lp);
+			gamma_index(std::execution::par, out, ref, tar, gp);
+
+			gamma_index(std::execution::par_unseq, out, ref, tar, lp);
+			gamma_index(std::execution::par_unseq, out, ref, tar, gp);
+		}
+		// 2
+		{
+			auto& out = *(iwritable_image<double, 2>*)(nullptr);
+			auto& ref = *(irtdose_image<double, 2>*)(nullptr);
+			auto& tar = *(irtdose_image<double, 2>*)(nullptr);
+			local_gamma_index_params<double> lp{ 0,0 };
+			global_gamma_index_params<double> gp{ 0,0 };
+
+			gamma_index(std::execution::seq, out, ref, tar, lp);
+			gamma_index(std::execution::seq, out, ref, tar, gp);
+
+			gamma_index(std::execution::unseq, out, ref, tar, lp);
+			gamma_index(std::execution::unseq, out, ref, tar, gp);
+
+			gamma_index(std::execution::par, out, ref, tar, lp);
+			gamma_index(std::execution::par, out, ref, tar, gp);
+
+			gamma_index(std::execution::par_unseq, out, ref, tar, lp);
+			gamma_index(std::execution::par_unseq, out, ref, tar, gp);
+		}
+		// 3
+		{
+			auto& out = *(iwritable_image<double, 3>*)(nullptr);
+			auto& ref = *(irtdose_image<double, 3>*)(nullptr);
+			auto& tar = *(irtdose_image<double, 3>*)(nullptr);
+			local_gamma_index_params<double> lp{ 0,0 };
+			global_gamma_index_params<double> gp{ 0,0 };
+
+			gamma_index(std::execution::seq, out, ref, tar, lp);
+			gamma_index(std::execution::seq, out, ref, tar, gp);
+
+			gamma_index(std::execution::unseq, out, ref, tar, lp);
+			gamma_index(std::execution::unseq, out, ref, tar, gp);
+
+			gamma_index(std::execution::par, out, ref, tar, lp);
+			gamma_index(std::execution::par, out, ref, tar, gp);
+
+			gamma_index(std::execution::par_unseq, out, ref, tar, lp);
+			gamma_index(std::execution::par_unseq, out, ref, tar, gp);
+		}
+	}
+}

--- a/gi_core/tests/math_gi_single_tests.cpp
+++ b/gi_core/tests/math_gi_single_tests.cpp
@@ -1,0 +1,359 @@
+#include <math/gamma_index.hpp>
+#include <math/vectorized/gamma_index_single.hpp>
+#include <boost/test/unit_test.hpp>
+
+#include <random>
+#include <chrono>
+
+using namespace yagit::core::math;
+using namespace yagit::core::data;
+using namespace std;
+using namespace std::chrono;
+
+BOOST_AUTO_TEST_CASE(single_relative_correctness_float)
+{
+	BOOST_TEST_MESSAGE("------------ single_relative_correctness_float ------------");
+
+	random_device r;
+	default_random_engine e1(r());
+	uniform_real_distribution<float> uniform_dist(0.0, 10.0f);
+
+	constexpr size_t S = 16;
+	constexpr float epsilon = 1e-4;
+
+	array<float, S> output_seq;
+	array<float, S> output_unseq;
+
+	array<float, S> ref_doses;
+	array<float, S> ref_x;
+	array<float, S> ref_y;
+	array<float, S> ref_z;
+
+	array<float, S> tar_doses;
+	array<float, S> tar_x;
+	array<float, S> tar_y;
+	array<float, S> tar_z;
+
+	auto gen = [&]() {return uniform_dist(e1); };
+
+	std::generate_n(ref_doses.data(), S, gen);
+	std::generate_n(ref_x.data(), S, gen);
+	std::generate_n(ref_y.data(), S, gen);
+	std::generate_n(ref_z.data(), S, gen);
+
+	std::generate_n(tar_doses.data(), S, gen);
+	std::generate_n(tar_x.data(), S, gen);
+	std::generate_n(tar_y.data(), S, gen);
+	std::generate_n(tar_z.data(), S, gen);
+
+	BOOST_TEST_MESSAGE("-------- local --------");
+	{
+		local_gamma_index_params<float> params{ 0.5f, 12.0f };
+		vectorized::vlocal_gamma_index_params<float, S> vparams{ params };
+		BOOST_TEST_MESSAGE("---- 1D ----");
+		{
+			for (size_t i = 0; i < S; i++)
+				output_seq[i] = basic::gamma_index(ref_doses[i], tar_doses[i], ref_x[i], tar_x[i], params);
+
+			simdpp::store_u(output_unseq.data(),
+				vectorized::gamma_index(
+					(simdpp::float32<S>)simdpp::load_u(ref_doses.data()),
+					(simdpp::float32<S>)simdpp::load_u(tar_doses.data()),
+					(simdpp::float32<S>)simdpp::load_u(ref_x.data()),
+					(simdpp::float32<S>)simdpp::load_u(tar_x.data()),
+					vparams
+				));
+
+			auto comp = [](auto a, auto b) {return std::abs(a - b) < epsilon; };
+			auto unseq_equal_to_seq = equal(execution::par_unseq, output_seq.data(), output_seq.data() + S, output_unseq.data(), output_unseq.data() + S, comp);
+
+			BOOST_CHECK(unseq_equal_to_seq);
+		}
+		BOOST_TEST_MESSAGE("---- 2D ----");
+		{
+			for (size_t i = 0; i < S; i++)
+				output_seq[i] = basic::gamma_index(ref_doses[i], tar_doses[i], ref_x[i], ref_y[i], tar_x[i], tar_y[i], params);
+
+			simdpp::store_u(output_unseq.data(),
+				vectorized::gamma_index(
+					(simdpp::float32<S>)simdpp::load_u(ref_doses.data()),
+					(simdpp::float32<S>)simdpp::load_u(tar_doses.data()),
+					(simdpp::float32<S>)simdpp::load_u(ref_x.data()),
+					(simdpp::float32<S>)simdpp::load_u(ref_y.data()),
+					(simdpp::float32<S>)simdpp::load_u(tar_x.data()),
+					(simdpp::float32<S>)simdpp::load_u(tar_y.data()),
+					vparams
+				));
+
+			auto comp = [](auto a, auto b) {return std::abs(a - b) < epsilon; };
+			auto unseq_equal_to_seq = equal(execution::par_unseq, output_seq.data(), output_seq.data() + S, output_unseq.data(), output_unseq.data() + S, comp);
+
+			BOOST_CHECK(unseq_equal_to_seq);
+		}
+		BOOST_TEST_MESSAGE("---- 3D ----");
+		{
+			for (size_t i = 0; i < S; i++)
+				output_seq[i] = basic::gamma_index(ref_doses[i], tar_doses[i], ref_x[i], ref_y[i], ref_z[i], tar_x[i], tar_y[i], tar_z[i], params);
+
+			simdpp::store_u(output_unseq.data(),
+				vectorized::gamma_index(
+					(simdpp::float32<S>)simdpp::load_u(ref_doses.data()),
+					(simdpp::float32<S>)simdpp::load_u(tar_doses.data()),
+					(simdpp::float32<S>)simdpp::load_u(ref_x.data()),
+					(simdpp::float32<S>)simdpp::load_u(ref_y.data()),
+					(simdpp::float32<S>)simdpp::load_u(ref_z.data()),
+					(simdpp::float32<S>)simdpp::load_u(tar_x.data()),
+					(simdpp::float32<S>)simdpp::load_u(tar_y.data()),
+					(simdpp::float32<S>)simdpp::load_u(tar_z.data()),
+					vparams
+				));
+
+			auto comp = [](auto a, auto b) {return std::abs(a - b) < epsilon; };
+			auto unseq_equal_to_seq = equal(execution::par_unseq, output_seq.data(), output_seq.data() + S, output_unseq.data(), output_unseq.data() + S, comp);
+
+			BOOST_CHECK(unseq_equal_to_seq);
+		}
+	}
+	BOOST_TEST_MESSAGE("-------- global --------");
+	{
+		global_gamma_index_params<float> params{ 1.0f, 2.0f };
+		vectorized::vglobal_gamma_index_params<float, S> vparams{ params };
+		BOOST_TEST_MESSAGE("---- 1D ----");
+		{
+			for (size_t i = 0; i < S; i++)
+				output_seq[i] = basic::gamma_index(ref_doses[i], tar_doses[i], ref_x[i], tar_x[i], params);
+
+			simdpp::store_u(output_unseq.data(),
+				vectorized::gamma_index(
+					(simdpp::float32<S>)simdpp::load_u(ref_doses.data()),
+					(simdpp::float32<S>)simdpp::load_u(tar_doses.data()),
+					(simdpp::float32<S>)simdpp::load_u(ref_x.data()),
+					(simdpp::float32<S>)simdpp::load_u(tar_x.data()),
+					vparams
+				));
+
+			auto comp = [](auto a, auto b) {return std::abs(a - b) < epsilon; };
+			auto unseq_equal_to_seq = equal(execution::par_unseq, output_seq.data(), output_seq.data() + S, output_unseq.data(), output_unseq.data() + S, comp);
+
+			BOOST_CHECK(unseq_equal_to_seq);
+		}
+		BOOST_TEST_MESSAGE("---- 2D ----");
+		{
+			for (size_t i = 0; i < S; i++)
+				output_seq[i] = basic::gamma_index(ref_doses[i], tar_doses[i], ref_x[i], ref_y[i], tar_x[i], tar_y[i], params);
+
+			simdpp::store_u(output_unseq.data(),
+				vectorized::gamma_index(
+					(simdpp::float32<S>)simdpp::load_u(ref_doses.data()),
+					(simdpp::float32<S>)simdpp::load_u(tar_doses.data()),
+					(simdpp::float32<S>)simdpp::load_u(ref_x.data()),
+					(simdpp::float32<S>)simdpp::load_u(ref_y.data()),
+					(simdpp::float32<S>)simdpp::load_u(tar_x.data()),
+					(simdpp::float32<S>)simdpp::load_u(tar_y.data()),
+					vparams
+				));
+
+			auto comp = [](auto a, auto b) {return std::abs(a - b) < epsilon; };
+			auto unseq_equal_to_seq = equal(execution::par_unseq, output_seq.data(), output_seq.data() + S, output_unseq.data(), output_unseq.data() + S, comp);
+
+			BOOST_CHECK(unseq_equal_to_seq);
+		}
+		BOOST_TEST_MESSAGE("---- 3D ----");
+		{
+			for (size_t i = 0; i < S; i++)
+				output_seq[i] = basic::gamma_index(ref_doses[i], tar_doses[i], ref_x[i], ref_y[i], ref_z[i], tar_x[i], tar_y[i], tar_z[i], params);
+
+			simdpp::store_u(output_unseq.data(),
+				vectorized::gamma_index(
+					(simdpp::float32<S>)simdpp::load_u(ref_doses.data()),
+					(simdpp::float32<S>)simdpp::load_u(tar_doses.data()),
+					(simdpp::float32<S>)simdpp::load_u(ref_x.data()),
+					(simdpp::float32<S>)simdpp::load_u(ref_y.data()),
+					(simdpp::float32<S>)simdpp::load_u(ref_z.data()),
+					(simdpp::float32<S>)simdpp::load_u(tar_x.data()),
+					(simdpp::float32<S>)simdpp::load_u(tar_y.data()),
+					(simdpp::float32<S>)simdpp::load_u(tar_z.data()),
+					vparams
+				));
+
+			auto comp = [](auto a, auto b) {return std::abs(a - b) < epsilon; };
+			auto unseq_equal_to_seq = equal(execution::par_unseq, output_seq.data(), output_seq.data() + S, output_unseq.data(), output_unseq.data() + S, comp);
+
+			BOOST_CHECK(unseq_equal_to_seq);
+		}
+	}
+}
+
+BOOST_AUTO_TEST_CASE(single_relative_correctness_double)
+{
+	BOOST_TEST_MESSAGE("------------ single_relative_correctness_double ------------");
+
+	random_device r;
+	default_random_engine e1(r());
+	uniform_real_distribution<double> uniform_dist(0.0, 10.0f);
+
+	constexpr size_t S = 16;
+	constexpr double epsilon = 1e-4;
+
+	array<double, S> output_seq;
+	array<double, S> output_unseq;
+
+	array<double, S> ref_doses;
+	array<double, S> ref_x;
+	array<double, S> ref_y;
+	array<double, S> ref_z;
+
+	array<double, S> tar_doses;
+	array<double, S> tar_x;
+	array<double, S> tar_y;
+	array<double, S> tar_z;
+
+	auto gen = [&]() {return uniform_dist(e1); };
+
+	std::generate_n(ref_doses.data(), S, gen);
+	std::generate_n(ref_x.data(), S, gen);
+	std::generate_n(ref_y.data(), S, gen);
+	std::generate_n(ref_z.data(), S, gen);
+
+	std::generate_n(tar_doses.data(), S, gen);
+	std::generate_n(tar_x.data(), S, gen);
+	std::generate_n(tar_y.data(), S, gen);
+	std::generate_n(tar_z.data(), S, gen);
+
+	BOOST_TEST_MESSAGE("-------- local --------");
+	{
+		local_gamma_index_params<double> params{ 0.5f, 12.0f };
+		vectorized::vlocal_gamma_index_params<double, S> vparams{ params };
+		BOOST_TEST_MESSAGE("---- 1D ----");
+		{
+			for (size_t i = 0; i < S; i++)
+				output_seq[i] = basic::gamma_index(ref_doses[i], tar_doses[i], ref_x[i], tar_x[i], params);
+
+			simdpp::store_u(output_unseq.data(),
+				vectorized::gamma_index(
+					(simdpp::float64<S>)simdpp::load_u(ref_doses.data()),
+					(simdpp::float64<S>)simdpp::load_u(tar_doses.data()),
+					(simdpp::float64<S>)simdpp::load_u(ref_x.data()),
+					(simdpp::float64<S>)simdpp::load_u(tar_x.data()),
+					vparams
+				));
+
+			auto comp = [](auto a, auto b) {return std::abs(a - b) < epsilon; };
+			auto unseq_equal_to_seq = equal(execution::par_unseq, output_seq.data(), output_seq.data() + S, output_unseq.data(), output_unseq.data() + S, comp);
+
+			BOOST_CHECK(unseq_equal_to_seq);
+		}
+		BOOST_TEST_MESSAGE("---- 2D ----");
+		{
+			for (size_t i = 0; i < S; i++)
+				output_seq[i] = basic::gamma_index(ref_doses[i], tar_doses[i], ref_x[i], ref_y[i], tar_x[i], tar_y[i], params);
+
+			simdpp::store_u(output_unseq.data(),
+				vectorized::gamma_index(
+					(simdpp::float64<S>)simdpp::load_u(ref_doses.data()),
+					(simdpp::float64<S>)simdpp::load_u(tar_doses.data()),
+					(simdpp::float64<S>)simdpp::load_u(ref_x.data()),
+					(simdpp::float64<S>)simdpp::load_u(ref_y.data()),
+					(simdpp::float64<S>)simdpp::load_u(tar_x.data()),
+					(simdpp::float64<S>)simdpp::load_u(tar_y.data()),
+					vparams
+				));
+
+			auto comp = [](auto a, auto b) {return std::abs(a - b) < epsilon; };
+			auto unseq_equal_to_seq = equal(execution::par_unseq, output_seq.data(), output_seq.data() + S, output_unseq.data(), output_unseq.data() + S, comp);
+
+			BOOST_CHECK(unseq_equal_to_seq);
+		}
+		BOOST_TEST_MESSAGE("---- 3D ----");
+		{
+			for (size_t i = 0; i < S; i++)
+				output_seq[i] = basic::gamma_index(ref_doses[i], tar_doses[i], ref_x[i], ref_y[i], ref_z[i], tar_x[i], tar_y[i], tar_z[i], params);
+
+			simdpp::store_u(output_unseq.data(),
+				vectorized::gamma_index(
+					(simdpp::float64<S>)simdpp::load_u(ref_doses.data()),
+					(simdpp::float64<S>)simdpp::load_u(tar_doses.data()),
+					(simdpp::float64<S>)simdpp::load_u(ref_x.data()),
+					(simdpp::float64<S>)simdpp::load_u(ref_y.data()),
+					(simdpp::float64<S>)simdpp::load_u(ref_z.data()),
+					(simdpp::float64<S>)simdpp::load_u(tar_x.data()),
+					(simdpp::float64<S>)simdpp::load_u(tar_y.data()),
+					(simdpp::float64<S>)simdpp::load_u(tar_z.data()),
+					vparams
+				));
+
+			auto comp = [](auto a, auto b) {return std::abs(a - b) < epsilon; };
+			auto unseq_equal_to_seq = equal(execution::par_unseq, output_seq.data(), output_seq.data() + S, output_unseq.data(), output_unseq.data() + S, comp);
+
+			BOOST_CHECK(unseq_equal_to_seq);
+		}
+	}
+	BOOST_TEST_MESSAGE("-------- global --------");
+	{
+		global_gamma_index_params<double> params{ 0.5f, 12.0f };
+		vectorized::vglobal_gamma_index_params<double, S> vparams{ params };
+		BOOST_TEST_MESSAGE("---- 1D ----");
+		{
+			for (size_t i = 0; i < S; i++)
+				output_seq[i] = basic::gamma_index(ref_doses[i], tar_doses[i], ref_x[i], tar_x[i], params);
+
+			simdpp::store_u(output_unseq.data(),
+				vectorized::gamma_index(
+					(simdpp::float64<S>)simdpp::load_u(ref_doses.data()),
+					(simdpp::float64<S>)simdpp::load_u(tar_doses.data()),
+					(simdpp::float64<S>)simdpp::load_u(ref_x.data()),
+					(simdpp::float64<S>)simdpp::load_u(tar_x.data()),
+					vparams
+				));
+
+			auto comp = [](auto a, auto b) {return std::abs(a - b) < epsilon; };
+			auto unseq_equal_to_seq = equal(execution::par_unseq, output_seq.data(), output_seq.data() + S, output_unseq.data(), output_unseq.data() + S, comp);
+
+			BOOST_CHECK(unseq_equal_to_seq);
+		}
+		BOOST_TEST_MESSAGE("---- 2D ----");
+		{
+			for (size_t i = 0; i < S; i++)
+				output_seq[i] = basic::gamma_index(ref_doses[i], tar_doses[i], ref_x[i], ref_y[i], tar_x[i], tar_y[i], params);
+
+			simdpp::store_u(output_unseq.data(),
+				vectorized::gamma_index(
+					(simdpp::float64<S>)simdpp::load_u(ref_doses.data()),
+					(simdpp::float64<S>)simdpp::load_u(tar_doses.data()),
+					(simdpp::float64<S>)simdpp::load_u(ref_x.data()),
+					(simdpp::float64<S>)simdpp::load_u(ref_y.data()),
+					(simdpp::float64<S>)simdpp::load_u(tar_x.data()),
+					(simdpp::float64<S>)simdpp::load_u(tar_y.data()),
+					vparams
+				));
+
+			auto comp = [](auto a, auto b) {return std::abs(a - b) < epsilon; };
+			auto unseq_equal_to_seq = equal(execution::par_unseq, output_seq.data(), output_seq.data() + S, output_unseq.data(), output_unseq.data() + S, comp);
+
+			BOOST_CHECK(unseq_equal_to_seq);
+		}
+		BOOST_TEST_MESSAGE("---- 3D ----");
+		{
+			for (size_t i = 0; i < S; i++)
+				output_seq[i] = basic::gamma_index(ref_doses[i], tar_doses[i], ref_x[i], ref_y[i], ref_z[i], tar_x[i], tar_y[i], tar_z[i], params);
+
+			simdpp::store_u(output_unseq.data(),
+				vectorized::gamma_index(
+					(simdpp::float64<S>)simdpp::load_u(ref_doses.data()),
+					(simdpp::float64<S>)simdpp::load_u(tar_doses.data()),
+					(simdpp::float64<S>)simdpp::load_u(ref_x.data()),
+					(simdpp::float64<S>)simdpp::load_u(ref_y.data()),
+					(simdpp::float64<S>)simdpp::load_u(ref_z.data()),
+					(simdpp::float64<S>)simdpp::load_u(tar_x.data()),
+					(simdpp::float64<S>)simdpp::load_u(tar_y.data()),
+					(simdpp::float64<S>)simdpp::load_u(tar_z.data()),
+					vparams
+				));
+
+			auto comp = [](auto a, auto b) {return std::abs(a - b) < epsilon; };
+			auto unseq_equal_to_seq = equal(execution::par_unseq, output_seq.data(), output_seq.data() + S, output_unseq.data(), output_unseq.data() + S, comp);
+
+			BOOST_CHECK(unseq_equal_to_seq);
+		}
+	}
+}

--- a/gi_core/tests/memory_based_image.hpp
+++ b/gi_core/tests/memory_based_image.hpp
@@ -1,0 +1,3 @@
+#pragma once
+
+#include <data/iimage.hpp>

--- a/gi_core/tests/memory_based_image_region.hpp
+++ b/gi_core/tests/memory_based_image_region.hpp
@@ -1,0 +1,165 @@
+#pragma once
+
+#include <data/iimage_region.hpp>
+#include <algorithm>
+#include <numeric>
+
+using namespace yagit::core::data;
+
+enum class mbi_subregion_error
+{
+	invalid_subregion,
+	subregion_outside_bounds,
+	unknown
+};
+
+namespace std
+{
+	template <>
+	struct is_error_code_enum<mbi_subregion_error> : true_type {};
+}
+
+namespace 
+{
+	struct mbi_subregion_error_category : std::error_category
+	{
+		const char* name() const noexcept override {
+			return "memory_based_image_subregion_error";
+		}
+		std::string message(int ev) const override
+		{
+			switch (static_cast<mbi_subregion_error>(ev))
+			{
+			case mbi_subregion_error::invalid_subregion:
+				return "invalid_subregion";
+			case mbi_subregion_error::subregion_outside_bounds:
+				return "subregion_outside_bounds";
+			default:
+			case mbi_subregion_error::unknown:
+				return "unknown";
+			}
+		}
+	};
+}
+
+const mbi_subregion_error_category _mbi_subregion_error_cat{};
+
+template<size_t Dimensions>
+constexpr array<size_t, Dimensions> make_index_transform(const sizes<Dimensions>& sizes, const data_format<Dimensions>& target_format = default_format)
+{
+	static_assert(Dimensions >= 1);
+	std::array<size_t, N> index_transform{};
+	index_transform[target_format.order.back().dimension_index] = 1;
+
+	size_t partial_sum = sizes[target_format.order.back().dimension_index];
+	for (
+		auto format_order_element_it = target_format.order.rbegin() + 1;
+		format_order_element_it != target_format.order.rend();
+		partial_sum *= sizes[format_order_element_it->dimension_index])
+	{
+		index_transform[format_order_element_it->dimension_index] = partial_sum;
+	}
+	return index_transform;
+}
+
+template<size_t Dimensions>
+constexpr size_t calculate_index(const array<size_t, Dimensions>& index, const array<size_t, Dimensions>& index_transform)
+{
+	return std::transform_reduce(std::begin(index), std::end(index), std::begin(index_transform), static_cast<size_t>(0));
+}
+
+template<typename ElementType, size_t Dimensions>
+class memory_based_image_region
+	: iimage_region<ElementType, Dimensions>
+{
+	static_assert(Dimensions <= 3, "Dimensions higher that 3 are not supported!");
+protected:
+	std::shared_ptr<ElementType[]> _data;
+	sizes<Dimensions> _size;
+	data_region<Dimensions> _region;
+protected:
+	memory_based_image_region(
+		const std::shared_ptr<ElementType[]>& data,
+		const sizes<Dimensions>& size,
+		const data_region<Dimensions>& region)
+		: _data(data)
+		, _size(size)
+		, _region(region)
+	{
+	}
+private:
+	constexpr static std::error_code make_error_code(mbi_subregion_error e)
+	{
+		return { static_cast<int>(e), _mbi_subregion_error_cat };
+	}
+public:
+	virtual ~memory_based_image_region() override = default;
+public:
+	virtual data_format<Dimensions> preferred_data_format() const override { return default_format; }
+	virtual data_format<Dimensions> preferred_coordinates_format() const override { return default_format; }
+	virtual unique_ptr<iimage_region<ElementType, Dimensions>> subregion(const data_region<Dimensions>& region, error_code& ec) const
+	{
+		if (std::any_of(std::begin(region.size.sizes), std::end(region.size.sizes), [](auto s) {return s == 0; }))
+		{
+			ec = make_error_code(mbi_subregion_error::invalid_subregion);
+			return nullptr;
+		}
+
+		data_region<Dimensions> new_region;
+		std::transform(std::begin(_region.offset.offsets), std::end(_region.offset.offsets), std::begin(region.offset.offsets), std::begin(new_region.offset.offsets), std::plus<size_t>());
+		std::copy(std::begin(region.size.sizes), std::end(region.size.sizes), std::begin(new_region.size.sizes));
+
+		std::array<size_t, Dimensions> upper_bound_region;
+		std::array<size_t, Dimensions> upper_bound_new_region;
+		std::transform(std::begin(_region.offset.offsets), std::end(_region.offset.offsets), std::begin(_region.size.sizes), std::begin(upper_bound_region), std::plus<size_t>());
+		std::transform(std::begin(new_region.offset.offsets), std::end(new_region.offset.offsets), std::begin(new_region.size.sizes), std::begin(upper_bound_new_region), std::plus<size_t>());
+		std::array<bool, Dimensions> upper_bound_in_old_region;
+		std::transform(std::begin(upper_bound_new_region), std::end(upper_bound_new_region), std::begin(upper_bound_region), std::begin(upper_bound_in_old_region), std::less_equal<size_t>());
+		
+		if (!std::all_of(std::begin(upper_bound_in_old_region), std::end(upper_bound_in_old_region), [](auto in) {return in; }))
+		{
+			ec = make_error_code(mbi_subregion_error::invalid_subregion);
+			return nullptr;
+		}
+
+		ec = error_code();
+		return unique_ptr<iimage_region<ElementType, Dimensions>>(new memory_based_image_region(_data, _size, new_region));
+	}
+	virtual data_region<Dimensions> region() const noexcept { return _region; }
+	virtual error_code save(const image_data<ElementType, Dimensions>& data) override
+	{
+		if (data.region() != region())
+			return error_code();/*error*/;
+
+		if (data.format() == preferred_data_format())
+		{
+			if constexpr (Dimensions == 1)
+			{
+				std::copy(data.data(), data.data() + data.total_size(), _data.get() + _region.offset.offsets[0]);
+			}
+
+			if constexpr (Dimensions >= 2)
+			{
+				size_t to_row_length = _size.sizes[Dimensions - 1];
+				size_t from_row_length = data.size<Dimensions - 1>();
+				size_t from_size = data.total_size();
+				for (
+					auto from = data.data(),
+					auto from_end = data.data() + from_size,
+					to = _data.get() + _region.offset.offsets[Dimensions - 1];
+					from != from_end;
+					from += from_row_length;
+					to += to_row_length)
+				{
+					std::copy(from, from + from_row_length, to);
+				}
+			}
+
+			return error_code();
+		}
+	}
+protected:
+	virtual error_code load(ElementType* data_storage, const data_format<Dimensions>& format, size_t& required_size) const override;
+	virtual error_code load_coordinates(ElementType* data_storage, size_t dimension, const data_format<Dimensions>& format, size_t& required_size) const override;
+	virtual unique_ptr<iimage_region<ElementType, Dimensions - 1>> slice(size_t dimension, size_t index, error_code& ec) const override;
+};


### PR DESCRIPTION
- Added range based accelerated gamma_index calculators:
  - plain C++ code with compiler dependent OpenMP version
  - vectorized C++ code (libsimdpp) with compiler dependent OpenMP version
  - OpenCL accelerated gamma_index with VexCL (possibility to use CUDA as another backend in the library)