### PR TITLE
update gh actions workflows

### DIFF
--- a/.github/workflows/documentation-deploy.yml
+++ b/.github/workflows/documentation-deploy.yml
@@ -1,0 +1,44 @@
+name: documentation-deploy
+
+on:
+  release:
+    types: [ published ]
+
+jobs:
+  documentation:
+    if: github.repository == 'DataMedSci/yagit'
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+
+      - name: Install tools and dependencies
+        working-directory: ./docs
+        run: |
+          sudo apt update
+          sudo apt install doxygen
+          doxygen --version
+          python -m pip install -U pip
+          python -m pip install -r requirements.txt
+
+      - name: Run doxygen and sphinx
+        working-directory: ./docs
+        run: |
+          VERSION=${{ github.event.release.tag_name }}
+          (cat Doxyfile; echo PROJECT_NUMBER=$VERSION) | doxygen -
+          make html SPHINXOPTS=-Dversion=$VERSION
+
+      - name: Deploy documentation
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: docs/build/html

--- a/.github/workflows/documentation-deploy.yml
+++ b/.github/workflows/documentation-deploy.yml
@@ -5,7 +5,7 @@ on:
     types: [ published ]
 
 jobs:
-  documentation:
+  documentation-deploy:
     if: github.repository == 'DataMedSci/yagit'
     runs-on: ubuntu-latest
 

--- a/.github/workflows/documentation-deploy.yml
+++ b/.github/workflows/documentation-deploy.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.12'
 
       - name: Install tools and dependencies
         working-directory: ./docs

--- a/.github/workflows/documentation-test.yml
+++ b/.github/workflows/documentation-test.yml
@@ -1,12 +1,13 @@
-name: documentation
+name: documentation-test
 
 on:
-  release:
-    types: [ published ]
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
   documentation:
-    if: github.repository == 'DataMedSci/yagit'
     runs-on: ubuntu-latest
 
     permissions:
@@ -33,12 +34,14 @@ jobs:
       - name: Run doxygen and sphinx
         working-directory: ./docs
         run: |
-          VERSION=${{ github.event.release.tag_name }}
+          VERSION=$(git describe --tags --dirty --match "v*")
           (cat Doxyfile; echo PROJECT_NUMBER=$VERSION) | doxygen -
           make html SPHINXOPTS=-Dversion=$VERSION
 
-      - name: Deploy documentation
-        uses: peaceiris/actions-gh-pages@v4
+      - name: Upload documentation artifact
+        uses: actions/upload-artifact@v4
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: docs/build/html
+          name: yagit-documentation
+          path: docs/build/html
+          if-no-files-found: error
+          retention-days: 10

--- a/.github/workflows/documentation-test.yml
+++ b/.github/workflows/documentation-test.yml
@@ -34,7 +34,8 @@ jobs:
       - name: Run doxygen and sphinx
         working-directory: ./docs
         run: |
-          VERSION=${{ github.ref_name }}
+          VERSION_LONG=${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          VERSION=$(echo $VERSION_LONG | cut -c1-7)
           (cat Doxyfile; echo PROJECT_NUMBER=$VERSION) | doxygen -
           make html SPHINXOPTS=-Dversion=$VERSION
 
@@ -45,3 +46,4 @@ jobs:
           path: docs/build/html
           if-no-files-found: error
           retention-days: 10
+          include-hidden-files: true

--- a/.github/workflows/documentation-test.yml
+++ b/.github/workflows/documentation-test.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.12'
 
       - name: Install tools and dependencies
         working-directory: ./docs

--- a/.github/workflows/documentation-test.yml
+++ b/.github/workflows/documentation-test.yml
@@ -5,6 +5,10 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+    paths:
+      - 'docs/**'
+      - 'include/yagit/**'
+      - 'examples/**/*.cpp'
 
 jobs:
   documentation-test:

--- a/.github/workflows/documentation-test.yml
+++ b/.github/workflows/documentation-test.yml
@@ -7,7 +7,7 @@ on:
     branches: [ master ]
 
 jobs:
-  documentation:
+  documentation-test:
     runs-on: ubuntu-latest
 
     permissions:
@@ -34,7 +34,7 @@ jobs:
       - name: Run doxygen and sphinx
         working-directory: ./docs
         run: |
-          VERSION=$(git describe --tags --dirty --match "v*")
+          VERSION=${{ github.ref_name }}
           (cat Doxyfile; echo PROJECT_NUMBER=$VERSION) | doxygen -
           make html SPHINXOPTS=-Dversion=$VERSION
 

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -9,6 +9,9 @@ jobs:
     if: github.repository == 'DataMedSci/yagit'
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: write
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.9'
 
@@ -35,7 +35,7 @@ jobs:
           make html SPHINXOPTS=-Dversion=$VERSION
 
       - name: Deploy documentation
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: docs/build/html

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   documentation:
+    if: github.repository == 'DataMedSci/yagit'
     runs-on: ubuntu-latest
 
     steps:
@@ -18,7 +19,7 @@ jobs:
           python-version: '3.9'
 
       - name: Install tools and dependencies
-        working-directory: ${{ github.workspace }}/docs
+        working-directory: ./docs
         run: |
           sudo apt update
           sudo apt install doxygen
@@ -27,7 +28,7 @@ jobs:
           python -m pip install -r requirements.txt
 
       - name: Run doxygen and sphinx
-        working-directory: ${{ github.workspace }}/docs
+        working-directory: ./docs
         run: |
           VERSION=${{ github.event.release.tag_name }}
           (cat Doxyfile; echo PROJECT_NUMBER=$VERSION) | doxygen -

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,12 +50,13 @@ jobs:
           set_config  BUILD_DOCUMENTATION        OFF
           set_config  INSTALL                    ON
           set_config  INSTALL_DIR                ./yagit_install
+          cat setup.sh
 
       - name: Build and install yagit
         run: ./setup.sh
 
       - name: Run unit tests
-        run: ctest -C ${{ env.BUILD_TYPE }} --test-dir build --output-on-failure
+        run: ctest -C ${{ env.BUILD_TYPE }} --test-dir build --output-on-failure --no-tests=error
 
       - name: Run example
         run: ./build/examples/gammaSimple
@@ -89,37 +90,35 @@ jobs:
 
       - name: Check tools versions
         run: |
-          cl
           cmake --version
           conan --version
 
       - name: Configure setup.bat
         run: |
           where sed
-          echo sed -i "s|^\(\s*set \s*%1\)=.*|\1=%~2|" setup.bat > set_config.bat
-
-          set_config  BUILD_TYPE                 ${{ env.BUILD_TYPE }}
-          set_config  INSTALL_DEPENDENCIES       CONAN
-          set_config  GAMMA_VERSION              ${{ matrix.gamma-version }}
-          set_config  SIMD_EXTENSION             ${{ endsWith(matrix.gamma-version, 'SIMD') && 'AVX2' || 'DEFAULT' }}
-          set_config  BUILD_EXAMPLES             ON
-          set_config  BUILD_TESTING              ON
-          set_config  BUILD_PERFORMANCE_TESTING  ON
-          set_config  RUN_EXAMPLES               OFF
-          set_config  RUN_TESTING                OFF
-          set_config  RUN_PERFORMANCE_TESTING    OFF
-          set_config  BUILD_DOCUMENTATION        OFF
-          set_config  INSTALL                    ON
-          set_config  INSTALL_DIR                ./yagit_install
-
+          echo sed -i "s|^\(\s*set \s*%%1\)=.*|\1=%%~2|" setup.bat > set_config.bat
           type set_config.bat
+
+          call set_config  BUILD_TYPE                 ${{ env.BUILD_TYPE }}
+          call set_config  INSTALL_DEPENDENCIES       LOCAL
+          call set_config  GAMMA_VERSION              ${{ matrix.gamma-version }}
+          call set_config  SIMD_EXTENSION             ${{ endsWith(matrix.gamma-version, 'SIMD') && 'AVX2' || 'DEFAULT' }}
+          call set_config  BUILD_EXAMPLES             ON
+          call set_config  BUILD_TESTING              ON
+          call set_config  BUILD_PERFORMANCE_TESTING  ON
+          call set_config  RUN_EXAMPLES               OFF
+          call set_config  RUN_TESTING                OFF
+          call set_config  RUN_PERFORMANCE_TESTING    OFF
+          call set_config  BUILD_DOCUMENTATION        OFF
+          call set_config  INSTALL                    ON
+          call set_config  INSTALL_DIR                ./yagit_install
           type setup.bat
 
       - name: Build and install yagit
-        run: setup.bat
+        run: call setup.bat
 
       - name: Run unit tests
-        run: ctest -C ${{ env.BUILD_TYPE }} --test-dir build --output-on-failure
+        run: ctest -C ${{ env.BUILD_TYPE }} --test-dir build --output-on-failure --no-tests=error
 
       - name: Run example
         run: build\examples\${{ env.BUILD_TYPE }}\gammaSimple.exe

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build-deps-linux:
-    name: Build yagit dependencies on Linux
+    name: Build deps on Linux
     runs-on: ubuntu-latest
 
     steps:
@@ -18,7 +18,7 @@ jobs:
           sparse-checkout: setup.sh
           sparse-checkout-cone-mode: false
 
-      - name: Cache yagit dependencies
+      - name: Cache dependencies
         id: cache-deps
         uses: actions/cache@v4
         with:
@@ -40,7 +40,7 @@ jobs:
         run: ./setup.sh
 
   yagit-linux:
-    name: Build yagit on Linux
+    name: yagit on Linux
     runs-on: ubuntu-latest
     needs: build-deps-linux
 
@@ -53,8 +53,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Cache yagit dependencies
-        uses: actions/cache@v4
+      - name: Restore cached dependencies
+        uses: actions/cache/restore@v4
         with:
           path: |
             build/deps/GDCM/build/installed
@@ -91,7 +91,7 @@ jobs:
         run: ./build/examples/gammaSimple
 
   download-deps-windows:
-    name: Download yagit dependencies on Windows
+    name: Download deps on Windows
     runs-on: windows-2022
 
     defaults:
@@ -105,7 +105,7 @@ jobs:
           sparse-checkout: conanfile.txt
           sparse-checkout-cone-mode: false
 
-      - name: Cache yagit dependencies
+      - name: Cache dependencies
         id: cache-deps
         uses: actions/cache@v4
         with:
@@ -136,7 +136,7 @@ jobs:
           conan install ../.. --output-folder . --build missing
 
   yagit-windows:
-    name: Build yagit on Windows
+    name: yagit on Windows
     runs-on: windows-2022
     needs: download-deps-windows
 
@@ -153,9 +153,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Cache yagit dependencies
+      - name: Restore cached dependencies
         id: cache-deps
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: |
             build/deps_conan

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Check tools versions
         run: |
@@ -76,10 +76,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,9 +10,42 @@ env:
   BUILD_TYPE: Release
 
 jobs:
+  build-deps-linux:
+    name: Build yagit dependencies on Linux
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download script
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: setup.sh
+          sparse-checkout-cone-mode: false
+
+      - name: Cache yagit dependencies
+        id: cache-deps
+        uses: actions/cache@v4
+        with:
+          path: |
+            build/deps/GDCM/build/installed
+            build/deps/xsimd/build/installed
+            build/deps/googletest/build/installed
+          key: deps-local-${{ runner.os }}-${{ hashFiles('setup.sh') }}
+          lookup-only: true
+
+      - name: Set dependencies installation to local
+        if: steps.cache-deps.outputs.cache-hit != 'true'
+        run: |
+          set_config() { sed -i "s|^\(\s*$1\)=.*|\1=$2|" setup.sh; }
+          set_config  INSTALL_DEPENDENCIES  LOCAL
+
+      - name: Build dependencies
+        if: steps.cache-deps.outputs.cache-hit != 'true'
+        run: ./setup.sh
+
   yagit-linux:
     name: Build yagit on Linux
     runs-on: ubuntu-latest
+    needs: build-deps-linux
 
     strategy:
       matrix:
@@ -88,8 +121,8 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Cache yagit dependencies
-        uses: actions/cache@v4
         id: cache-deps
+        uses: actions/cache@v4
         with:
           path: |
             build/deps_conan

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,8 @@ jobs:
 
       - name: Build dependencies
         if: steps.cache-deps.outputs.cache-hit != 'true'
+        # script will fail after installing the deps while trying to build yagit, but we only need the deps
+        continue-on-error: true
         run: ./setup.sh
 
   yagit-linux:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,7 +84,9 @@ jobs:
           python-version: '3.10'
 
       - name: Install Conan
-        run: python -m pip install conan
+        run: |
+          python -m pip install conan
+          conan profile detect
 
       - name: Check tools versions
         run: |
@@ -96,7 +98,7 @@ jobs:
           echo sed -i "s|^\(\s*set \s*%%1\)=.*|\1=%%~2|" setup.bat > set_config.bat
 
           call set_config  BUILD_TYPE                 ${{ env.BUILD_TYPE }}
-          call set_config  INSTALL_DEPENDENCIES       LOCAL
+          call set_config  INSTALL_DEPENDENCIES       CONAN
           call set_config  GAMMA_VERSION              ${{ matrix.gamma-version }}
           call set_config  SIMD_EXTENSION             ${{ endsWith(matrix.gamma-version, 'SIMD') && 'AVX2' || 'DEFAULT' }}
           call set_config  BUILD_EXAMPLES             ON

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,9 +6,6 @@ on:
   pull_request:
     branches: [ master ]
 
-env:
-  BUILD_TYPE: Release
-
 jobs:
   build-deps-linux:
     name: Build yagit dependencies on Linux
@@ -49,11 +46,8 @@ jobs:
 
     strategy:
       matrix:
-        gamma-version:
-          - "SEQUENTIAL"
-          - "THREADS"
-          - "SIMD"
-          - "THREADS_SIMD"
+        gamma-version: ["SEQUENTIAL", "THREADS", "SIMD", "THREADS_SIMD"]
+        build-type: ["Release"]
 
     steps:
       - name: Checkout repository
@@ -67,18 +61,13 @@ jobs:
             build/deps/xsimd/build/installed
             build/deps/googletest/build/installed
           key: deps-local-${{ runner.os }}-${{ hashFiles('setup.sh') }}
-
-      - name: Check tools versions
-        run: |
-          gcc --version
-          g++ --version
-          cmake --version
+          fail-on-cache-miss: true
 
       - name: Configure setup.sh
         run: |
           set_config() { sed -i "s|^\(\s*$1\)=.*|\1=$2|" setup.sh; }
 
-          set_config  BUILD_TYPE                 ${{ env.BUILD_TYPE }}
+          set_config  BUILD_TYPE                 ${{ matrix.build-type }}
           set_config  INSTALL_DEPENDENCIES       LOCAL
           set_config  GAMMA_VERSION              ${{ matrix.gamma-version }}
           set_config  SIMD_EXTENSION             ${{ endsWith(matrix.gamma-version, 'SIMD') && 'AVX2' || 'DEFAULT' }}
@@ -96,29 +85,25 @@ jobs:
         run: ./setup.sh
 
       - name: Run unit tests
-        run: ctest -C ${{ env.BUILD_TYPE }} --test-dir build --output-on-failure --no-tests=error
+        run: ctest -C ${{ matrix.build-type }} --test-dir build --output-on-failure --no-tests=error
 
       - name: Run example
         run: ./build/examples/gammaSimple
 
-  yagit-windows:
-    name: Build yagit on Windows
+  download-deps-windows:
+    name: Download yagit dependencies on Windows
     runs-on: windows-2022
 
     defaults:
       run:
         shell: cmd
 
-    strategy:
-      matrix:
-        gamma-version:
-          - "SEQUENTIAL"
-          - "THREADS"
-          - "SIMD"
-
     steps:
-      - name: Checkout repository
+      - name: Download conanfile
         uses: actions/checkout@v4
+        with:
+          sparse-checkout: conanfile.txt
+          sparse-checkout-cone-mode: false
 
       - name: Cache yagit dependencies
         id: cache-deps
@@ -128,6 +113,7 @@ jobs:
             build/deps_conan
             ~/.conan2/p/**/p
           key: deps-conan-${{ runner.os }}-${{ hashFiles('conanfile.txt') }}
+          lookup-only: true
 
       - name: Set up Python
         if: steps.cache-deps.outputs.cache-hit != 'true'
@@ -142,15 +128,46 @@ jobs:
           conan profile detect
           conan --version
 
-      - name: Check tools versions
+      - name: Download dependencies
+        if: steps.cache-deps.outputs.cache-hit != 'true'
         run: |
-          cmake --version
+          mkdir build/deps_conan
+          cd build/deps_conan
+          conan install ../.. --output-folder . --build missing
+
+  yagit-windows:
+    name: Build yagit on Windows
+    runs-on: windows-2022
+    needs: download-deps-windows
+
+    defaults:
+      run:
+        shell: cmd
+
+    strategy:
+      matrix:
+        gamma-version: ["SEQUENTIAL", "THREADS", "SIMD"]
+        build-type: ["Release"]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Cache yagit dependencies
+        id: cache-deps
+        uses: actions/cache@v4
+        with:
+          path: |
+            build/deps_conan
+            ~/.conan2/p/**/p
+          key: deps-conan-${{ runner.os }}-${{ hashFiles('conanfile.txt') }}
+          fail-on-cache-miss: true
 
       - name: Configure setup.bat
         run: |
           echo sed -i "s|^\(\s*set \s*%%1\)=.*|\1=%%~2|" setup.bat > set_config.bat
 
-          call set_config  BUILD_TYPE                 ${{ env.BUILD_TYPE }}
+          call set_config  BUILD_TYPE                 ${{ matrix.build-type }}
           call set_config  INSTALL_DEPENDENCIES       CONAN
           call set_config  GAMMA_VERSION              ${{ matrix.gamma-version }}
           call set_config  SIMD_EXTENSION             ${{ endsWith(matrix.gamma-version, 'SIMD') && 'AVX2' || 'DEFAULT' }}
@@ -168,7 +185,7 @@ jobs:
         run: call setup.bat
 
       - name: Run unit tests
-        run: ctest -C ${{ env.BUILD_TYPE }} --test-dir build --output-on-failure --no-tests=error
+        run: ctest -C ${{ matrix.build-type }} --test-dir build --output-on-failure --no-tests=error
 
       - name: Run example
-        run: build\examples\${{ env.BUILD_TYPE }}\gammaSimple.exe
+        run: build\examples\${{ matrix.build-type }}\gammaSimple.exe

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,10 +78,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Set up Python and Conan
+      - name: Set up Python
         uses: actions/setup-python@v4
         with:
           python-version: '3.10'
+
+      - name: Install Conan
         run: python -m pip install conan
 
       - name: Check tools versions

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,15 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Cache yagit dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            build/deps/GDCM/build/installed
+            build/deps/xsimd/build/installed
+            build/deps/googletest/build/installed
+          key: deps-local-${{ runner.os }}-${{ hashFiles('setup.sh') }}
+
       - name: Check tools versions
         run: |
           gcc --version
@@ -78,20 +87,31 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Cache yagit dependencies
+        uses: actions/cache@v4
+        id: cache-deps
+        with:
+          path: |
+            build/deps_conan
+            ~/.conan2/p/**/p
+          key: deps-conan-${{ runner.os }}-${{ hashFiles('conanfile.txt') }}
+
       - name: Set up Python
+        if: steps.cache-deps.outputs.cache-hit != 'true'
         uses: actions/setup-python@v5
         with:
           python-version: '3.10'
 
       - name: Install Conan
+        if: steps.cache-deps.outputs.cache-hit != 'true'
         run: |
-          python -m pip install conan
+          python -m pip install conan==2.*
           conan profile detect
+          conan --version
 
       - name: Check tools versions
         run: |
           cmake --version
-          conan --version
 
       - name: Configure setup.bat
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -131,7 +131,7 @@ jobs:
         if: steps.cache-deps.outputs.cache-hit != 'true'
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.12'
 
       - name: Install Conan
         if: steps.cache-deps.outputs.cache-hit != 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,7 @@ jobs:
 
       - name: Configure setup.sh
         run: |
+          which sed
           set_config() { sed -i "s|^\(\s*$1\)=.*|\1=$2|" setup.sh; }
 
           set_config  BUILD_TYPE                 ${{ env.BUILD_TYPE }}
@@ -94,6 +95,7 @@ jobs:
 
       - name: Configure setup.bat
         run: |
+          where sed
           echo sed -i "s|^\(\s*set \s*%1\)=.*|\1=%~2|" setup.bat > set_config.bat
 
           set_config  BUILD_TYPE                 ${{ env.BUILD_TYPE }}
@@ -109,6 +111,9 @@ jobs:
           set_config  BUILD_DOCUMENTATION        OFF
           set_config  INSTALL                    ON
           set_config  INSTALL_DIR                ./yagit_install
+
+          type set_config.bat
+          type setup.bat
 
       - name: Build and install yagit
         run: setup.bat

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,15 +7,10 @@ on:
     branches: [ master ]
 
 env:
-  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Release
 
 jobs:
-  build-linux:
-    if: >
-      github.repository == 'DataMedSci/yagit' &&
-      !contains(github.event.head_commit.message, '[ci skip]') &&
-      !contains(github.event.head_commit.message, '[skip ci]')
+  yagit-linux:
     name: Build yagit on Linux
     runs-on: ubuntu-latest
 
@@ -31,90 +26,42 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Check versions
+      - name: Check tools versions
         run: |
           gcc --version
           g++ --version
           cmake --version
 
-      - name: Install dependencies
+      - name: Configure setup.sh
         run: |
-          sudo apt update
-          sudo apt install libgdcm-dev
+          set_config() { sed -i "s|^\(\s*$1\)=.*|\1=$2|" setup.sh; }
 
-      # install from source, because apt has old version
-      - name: Install xsimd
-        if: ${{ endsWith(matrix.gamma-version, 'SIMD') }}
-        run: |
-          git clone https://github.com/xtensor-stack/xsimd.git -b 11.1.0
-          cd xsimd
-          mkdir build && cd build
-          cmake ..
-          make
-          sudo make install
+          set_config  BUILD_TYPE                 ${{ env.BUILD_TYPE }}
+          set_config  INSTALL_DEPENDENCIES       LOCAL
+          set_config  GAMMA_VERSION              ${{ matrix.gamma-version }}
+          set_config  SIMD_EXTENSION             ${{ endsWith(matrix.gamma-version, 'SIMD') && 'AVX2' || 'DEFAULT' }}
+          set_config  BUILD_EXAMPLES             ON
+          set_config  BUILD_TESTING              ON
+          set_config  BUILD_PERFORMANCE_TESTING  ON
+          set_config  RUN_EXAMPLES               OFF
+          set_config  RUN_TESTING                OFF
+          set_config  RUN_PERFORMANCE_TESTING    OFF
+          set_config  BUILD_DOCUMENTATION        OFF
+          set_config  INSTALL                    ON
+          set_config  INSTALL_DIR                ./yagit_install
 
-      # install from source, because apt has old version
-      - name: Install GoogleTest and GoogleMock
-        run: |
-          git clone https://github.com/google/googletest.git -b v1.13.0
-          cd googletest
-          mkdir build && cd build
-          cmake ..
-          make
-          sudo make install
-
-      - name: Configure and build with CMake
-        run: |
-          mkdir build && cd build
-          cmake .. -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} \
-                   -DGAMMA_VERSION=${{ matrix.gamma-version }} \
-                   -DSIMD_EXTENSION=${{ endsWith(matrix.gamma-version, 'SIMD') && 'AVX2' || 'DEFAULT' }} \
-                   -DBUILD_EXAMPLES=ON \
-                   -DBUILD_TESTING=ON \
-                   -DBUILD_PERFORMANCE_TESTING=ON
-          cmake --build . -j
+      - name: Build and install yagit
+        run: ./setup.sh
 
       - name: Run unit tests
-        run: |
-          ctest --test-dir build --output-on-failure
+        run: ctest -C ${{ env.BUILD_TYPE }} --test-dir build --output-on-failure
 
       - name: Run example
-        run: |
-          ./build/examples/gammaSimple
+        run: ./build/examples/gammaSimple
 
-      - name: Install yagit
-        run: |
-          cmake --install build --prefix ./yagit_install_dir
-
-  run-setup-linux:
-    if: >
-      github.repository == 'DataMedSci/yagit' &&
-      !contains(github.event.head_commit.message, '[ci skip]') &&
-      !contains(github.event.head_commit.message, '[skip ci]')
-    name: Run setup.sh on Linux
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-
-      - name: Check versions
-        run: |
-          gcc --version
-          g++ --version
-          cmake --version
-
-      - name: Run setup.sh script
-        run: |
-          ./setup.sh
-
-  build-windows:
-    if: >
-      github.repository == 'DataMedSci/yagit' &&
-      !contains(github.event.head_commit.message, '[ci skip]') &&
-      !contains(github.event.head_commit.message, '[skip ci]')
+  yagit-windows:
     name: Build yagit on Windows
-    runs-on: windows-2019
+    runs-on: windows-2022
 
     defaults:
       run:
@@ -131,41 +78,41 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Check versions
-        run: |
-          cmake --version
-
-      - name: Set up Python
+      - name: Set up Python and Conan
         uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: '3.10'
+        run: python -m pip install conan
 
-      - name: Install dependencies
+      - name: Check tools versions
         run: |
-          python -m pip install "conan<2"
-          mkdir build && cd build
-          conan install ..
+          cl
+          cmake --version
+          conan --version
 
-      - name: Configure and build with CMake
-        working-directory: ${{ github.workspace }}/build
+      - name: Configure setup.bat
         run: |
-          cmake .. -DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake ^
-                   -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} ^
-                   -DGAMMA_VERSION=${{ matrix.gamma-version }} ^
-                   -DSIMD_EXTENSION=${{ endsWith(matrix.gamma-version, 'SIMD') && 'AVX2' || 'DEFAULT' }} ^
-                   -DBUILD_EXAMPLES=ON ^
-                   -DBUILD_TESTING=ON ^
-                   -DBUILD_PERFORMANCE_TESTING=ON
-          cmake --build . --config ${{ env.BUILD_TYPE }} -j
+          echo sed -i "s|^\(\s*set \s*%1\)=.*|\1=%~2|" setup.bat > set_config.bat
+
+          set_config  BUILD_TYPE                 ${{ env.BUILD_TYPE }}
+          set_config  INSTALL_DEPENDENCIES       CONAN
+          set_config  GAMMA_VERSION              ${{ matrix.gamma-version }}
+          set_config  SIMD_EXTENSION             ${{ endsWith(matrix.gamma-version, 'SIMD') && 'AVX2' || 'DEFAULT' }}
+          set_config  BUILD_EXAMPLES             ON
+          set_config  BUILD_TESTING              ON
+          set_config  BUILD_PERFORMANCE_TESTING  ON
+          set_config  RUN_EXAMPLES               OFF
+          set_config  RUN_TESTING                OFF
+          set_config  RUN_PERFORMANCE_TESTING    OFF
+          set_config  BUILD_DOCUMENTATION        OFF
+          set_config  INSTALL                    ON
+          set_config  INSTALL_DIR                ./yagit_install
+
+      - name: Build and install yagit
+        run: setup.bat
 
       - name: Run unit tests
-        run: |
-          ctest -C ${{ env.BUILD_TYPE }} --test-dir build --output-on-failure
+        run: ctest -C ${{ env.BUILD_TYPE }} --test-dir build --output-on-failure
 
       - name: Run example
-        run: |
-          build\examples\${{ env.BUILD_TYPE }}\gammaSimple.exe
-
-      - name: Install yagit
-        run: |
-          cmake --install build --prefix ./yagit_install_dir
+        run: build\examples\${{ env.BUILD_TYPE }}\gammaSimple.exe

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -131,8 +131,8 @@ jobs:
       - name: Download dependencies
         if: steps.cache-deps.outputs.cache-hit != 'true'
         run: |
-          mkdir build/deps_conan
-          cd build/deps_conan
+          mkdir build\deps_conan
+          cd build\deps_conan
           conan install ../.. --output-folder . --build missing
 
   yagit-windows:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,8 +46,9 @@ jobs:
 
     strategy:
       matrix:
-        gamma-version: ["SEQUENTIAL", "THREADS", "SIMD", "THREADS_SIMD"]
-        build-type: ["Release"]
+        gamma-version: [SEQUENTIAL, THREADS, SIMD, THREADS_SIMD]
+        include:
+          - build-type: Release
 
     steps:
       - name: Checkout repository
@@ -146,8 +147,9 @@ jobs:
 
     strategy:
       matrix:
-        gamma-version: ["SEQUENTIAL", "THREADS", "SIMD"]
-        build-type: ["Release"]
+        gamma-version: [SEQUENTIAL, THREADS, SIMD]
+        include:
+          - build-type: Release
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,6 @@ jobs:
 
       - name: Configure setup.sh
         run: |
-          which sed
           set_config() { sed -i "s|^\(\s*$1\)=.*|\1=$2|" setup.sh; }
 
           set_config  BUILD_TYPE                 ${{ env.BUILD_TYPE }}
@@ -50,7 +49,6 @@ jobs:
           set_config  BUILD_DOCUMENTATION        OFF
           set_config  INSTALL                    ON
           set_config  INSTALL_DIR                ./yagit_install
-          cat setup.sh
 
       - name: Build and install yagit
         run: ./setup.sh
@@ -95,9 +93,7 @@ jobs:
 
       - name: Configure setup.bat
         run: |
-          where sed
           echo sed -i "s|^\(\s*set \s*%%1\)=.*|\1=%%~2|" setup.bat > set_config.bat
-          type set_config.bat
 
           call set_config  BUILD_TYPE                 ${{ env.BUILD_TYPE }}
           call set_config  INSTALL_DEPENDENCIES       LOCAL
@@ -112,7 +108,6 @@ jobs:
           call set_config  BUILD_DOCUMENTATION        OFF
           call set_config  INSTALL                    ON
           call set_config  INSTALL_DIR                ./yagit_install
-          type setup.bat
 
       - name: Build and install yagit
         run: call setup.bat

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,9 @@ jobs:
     name: Build deps on Linux
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+
     steps:
       - name: Download script
         uses: actions/checkout@v4
@@ -45,6 +48,9 @@ jobs:
     name: yagit on Linux
     runs-on: ubuntu-latest
     needs: build-deps-linux
+
+    permissions:
+      contents: read
 
     strategy:
       matrix:
@@ -97,6 +103,9 @@ jobs:
     name: Download deps on Windows
     runs-on: windows-2022
 
+    permissions:
+      contents: read
+
     defaults:
       run:
         shell: cmd
@@ -142,6 +151,9 @@ jobs:
     name: yagit on Windows
     runs-on: windows-2022
     needs: download-deps-windows
+
+    permissions:
+      contents: read
 
     defaults:
       run:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -6,7 +6,7 @@
 # -- Project information -----------------------------------------------------
 project = "Yet Another Gamma Index Tool"
 author = f"YAGIT Developers"
-copyright = f"2023-2024, {author}"
+copyright = f"2023-2025, {author}"
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -45,16 +45,17 @@ On Windows, run:
 
    setup.bat
 
+Running the setup script may result in high CPU and memory usage, as it builds dependencies in parallel.
 
-Note that these scripts will only build the library and not install it by default.
-To install it, configure the options appropriately in the script file.
+Note that by default, these scripts only build the library and do not install it.
+To install the library, configure the installation options in the script.
 
 
 Script options
 ~~~~~~~~~~~~~~
 
-You can freely configure the options that are in the script files.
-Some of the options are the same as in the `CMake YAGIT options`_ section, as they are simply passed to CMake.
+You can freely configure the options in the script files.
+Some options are the same as those in the `CMake YAGIT options`_ section, as they are passed directly to CMake.
 
 .. rst-class:: wrap-text
 .. table::
@@ -201,8 +202,8 @@ CMake YAGIT options
    |                               |                        |             | option if the compiler supports it.        |
    +-------------------------------+------------------------+-------------+--------------------------------------------+
 
-To use these options, pass them to CMake during configuration using ``-D<option>=<value>``
-(e.g., ``cmake .. -DGAMMA_VERSION=THREADS_SIMD -DSIMD_EXTENSION=AVX2``).
+To use these options, pass them to CMake during configuration using ``-D<option>=<value>`` argument
+(for example: ``cmake .. -DGAMMA_VERSION=THREADS_SIMD -DSIMD_EXTENSION=AVX2``).
 
 
 CMake YAGIT integration

--- a/setup.bat
+++ b/setup.bat
@@ -60,7 +60,7 @@ if DEFINED INSTALL_LOCAL_GLOBAL (
 
     call :install_lib https://github.com/malaterre/GDCM.git v3.0.22 %INSTALL_DEPENDENCIES% "-DGDCM_BUILD_DOCBOOK_MANPAGES=OFF"
     call :install_lib https://github.com/xtensor-stack/xsimd.git 11.1.0 %INSTALL_DEPENDENCIES%
-    call :install_lib https://github.com/google/googletest.git v1.13.0 %INSTALL_DEPENDENCIES%
+    call :install_lib https://github.com/google/googletest.git v1.13.0 %INSTALL_DEPENDENCIES% "-Dgtest_force_shared_crt=ON"
 
     if %INSTALL_DEPENDENCIES% == LOCAL (
         set DEPENDENCIES_PATHS="%GDCM_PATH%;%XSIMD_PATH%;%GTEST_PATH%"

--- a/setup.sh
+++ b/setup.sh
@@ -120,14 +120,14 @@ cmake .. -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
          -DBUILD_PERFORMANCE_TESTING=$BUILD_PERFORMANCE_TESTING \
          -DCMAKE_PREFIX_PATH="$DEPENDENCIES_PATHS" \
          -DCMAKE_TOOLCHAIN_FILE="$TOOLCHAIN_FILE"
-if [ $? -ne 0 ]; then exit $?; fi
+status=$?; if [ $status -ne 0 ]; then exit $status; fi
 
 
 # ============================================================
 echo ""
 echo "BUILDING..."
 cmake --build . --config $BUILD_TYPE -j
-if [ $? -ne 0 ]; then exit $?; fi
+status=$?; if [ $status -ne 0 ]; then exit $status; fi
 cd ..
 
 

--- a/setup.sh
+++ b/setup.sh
@@ -54,12 +54,12 @@ install_lib () {
     repo_name_git=${1##*/}
     repo_name=${repo_name_git%.git}
 
-    if [ ! -d $repo_name ]; then
+    if [ ! -d "$repo_name" ]; then
         # clone git repo
         git clone $1 -b $2 --depth 1 -c advice.detachedHead=false
     fi
 
-    if [[ -d $repo_name && ! -d $repo_name/build ]]; then
+    if [[ -d "$repo_name" && ! -d "$repo_name/build" ]]; then
         cd $repo_name
         mkdir -p build && cd build
 

--- a/setup.sh
+++ b/setup.sh
@@ -48,6 +48,7 @@ install_lib () {
     # $1 - url to git repository of the library that will be installed
     # $2 - tag or branch of the library
     # $3 - installation mode (LOCAL or GLOBAL)
+    # $4 (optional) - additional options for cmake configure
 
     # extract repository name from url
     repo_name_git=${1##*/}
@@ -58,12 +59,12 @@ install_lib () {
         git clone $1 -b $2 --depth 1 -c advice.detachedHead=false
     fi
 
-    if [ ! -d $repo_name/build ]; then
+    if [[ -d $repo_name && ! -d $repo_name/build ]]; then
         cd $repo_name
         mkdir -p build && cd build
 
         # configure and build
-        cmake .. -DCMAKE_BUILD_TYPE=Release
+        cmake .. -DCMAKE_BUILD_TYPE=Release $4
         cmake --build . --config Release -j
 
         # install
@@ -81,7 +82,7 @@ if [[ $INSTALL_DEPENDENCIES == LOCAL || $INSTALL_DEPENDENCIES == GLOBAL ]]; then
     echo "INSTALLING DEPENDENCIES..."
     mkdir -p deps && cd deps
 
-    install_lib https://github.com/malaterre/GDCM.git v3.0.22 $INSTALL_DEPENDENCIES
+    install_lib https://github.com/malaterre/GDCM.git v3.0.22 $INSTALL_DEPENDENCIES "-DGDCM_BUILD_DOCBOOK_MANPAGES=OFF"
     install_lib https://github.com/xtensor-stack/xsimd.git 11.1.0 $INSTALL_DEPENDENCIES
     install_lib https://github.com/google/googletest.git v1.13.0 $INSTALL_DEPENDENCIES
 
@@ -119,18 +120,15 @@ cmake .. -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
          -DBUILD_PERFORMANCE_TESTING=$BUILD_PERFORMANCE_TESTING \
          -DCMAKE_PREFIX_PATH="$DEPENDENCIES_PATHS" \
          -DCMAKE_TOOLCHAIN_FILE="$TOOLCHAIN_FILE"
+if [ $? -ne 0 ]; then exit $?; fi
 
 
 # ============================================================
 echo ""
 echo "BUILDING..."
 cmake --build . --config $BUILD_TYPE -j
-COMPILE_RESULT=$?
+if [ $? -ne 0 ]; then exit $?; fi
 cd ..
-
-if [ $COMPILE_RESULT -ne 0 ]; then
-    exit $COMPILE_RESULT
-fi
 
 
 # ============================================================

--- a/tests/unit/ImageDataTest.cpp
+++ b/tests/unit/ImageDataTest.cpp
@@ -1,5 +1,5 @@
 /********************************************************************************************
- * Copyright (C) 2023-2024 'Yet Another Gamma Index Tool' Developers.
+ * Copyright (C) 2023-2025 'Yet Another Gamma Index Tool' Developers.
  * 
  * This file is part of 'Yet Another Gamma Index Tool'.
  * 
@@ -514,14 +514,18 @@ TEST(ImageDataTest, getImageData3DSagittal){
 
 TEST(ImageDataTest, min){
     EXPECT_FLOAT_EQ(-13.5, IMAGE_DATA_SMALL.min());
+    #if defined(__GNUC__) // skip this test on msvc because of different NaN comparison behavior
     EXPECT_THAT(IMAGE_DATA_SMALL_WITH_NANS.min(), IsNan());
+    #endif
     EXPECT_FLOAT_EQ(-13.5, IMAGE_DATA_SMALL_WITH_INFS.min());
     EXPECT_FLOAT_EQ(-INF, IMAGE_DATA_SMALL_WITH_INFS2.min());
 }
 
 TEST(ImageDataTest, max){
     EXPECT_FLOAT_EQ(20.4, IMAGE_DATA_SMALL.max());
+    #if defined(__GNUC__) // skip this test on msvc because of different NaN comparison behavior
     EXPECT_THAT(IMAGE_DATA_SMALL_WITH_NANS.max(), IsNan());
+    #endif
     EXPECT_FLOAT_EQ(INF, IMAGE_DATA_SMALL_WITH_INFS.max());
     EXPECT_FLOAT_EQ(INF, IMAGE_DATA_SMALL_WITH_INFS2.max());
 }

--- a/tests/unit/ImageDataTest.cpp
+++ b/tests/unit/ImageDataTest.cpp
@@ -514,7 +514,7 @@ TEST(ImageDataTest, getImageData3DSagittal){
 
 TEST(ImageDataTest, min){
     EXPECT_FLOAT_EQ(-13.5, IMAGE_DATA_SMALL.min());
-    #if defined(__GNUC__) // skip this test on msvc because of different NaN comparison behavior
+    #if !defined(_MSC_VER) // skip this test on msvc because of different NaN comparison behavior
     EXPECT_THAT(IMAGE_DATA_SMALL_WITH_NANS.min(), IsNan());
     #endif
     EXPECT_FLOAT_EQ(-13.5, IMAGE_DATA_SMALL_WITH_INFS.min());
@@ -523,7 +523,7 @@ TEST(ImageDataTest, min){
 
 TEST(ImageDataTest, max){
     EXPECT_FLOAT_EQ(20.4, IMAGE_DATA_SMALL.max());
-    #if defined(__GNUC__) // skip this test on msvc because of different NaN comparison behavior
+    #if !defined(_MSC_VER) // skip this test on msvc because of different NaN comparison behavior
     EXPECT_THAT(IMAGE_DATA_SMALL_WITH_NANS.max(), IsNan());
     #endif
     EXPECT_FLOAT_EQ(INF, IMAGE_DATA_SMALL_WITH_INFS.max());


### PR DESCRIPTION
List of changes:
- improved `test` workflow
  - changed jobs to use setup scripts to avoid code duplication and unify build process
  - added jobs on Linux and Windows that build and cache all dependencies, improving workflow execution time
  - changed `windows-2019` to `windows-2022`
- added permissions to each job
- updated actions versions and python version in workflows
- made improvements and fixes in `setup.sh` and `setup.bat`
- added `documentation-test` workflow to verify that documentation can be built
- renamed `documentation` workflow to `documentation-deploy`
- added info about high cpu and ram usage during parallel build (closed #74)